### PR TITLE
Place production Container App Environment in a separate region

### DIFF
--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -14,6 +14,7 @@ module "stack" {
 
   environment                = "production"
   resource_group_name        = var.resource_group_name
+  location                   = var.location
   log_analytics_workspace_id = data.terraform_remote_state.shared.outputs.log_analytics_workspace_id
   acr_login_server           = data.terraform_remote_state.shared.outputs.acr_login_server
   acr_pull_identity_id       = data.terraform_remote_state.shared.outputs.acr_pull_identity_id

--- a/infra/terraform/environments/production/variables.tf
+++ b/infra/terraform/environments/production/variables.tf
@@ -9,6 +9,12 @@ variable "resource_group_name" {
   default     = "rg-czw-production"
 }
 
+variable "location" {
+  type        = string
+  description = "Region for the production Container App Environment. Differs from staging (Central US) because free-trial subscriptions allow only 1 environment per region."
+  default     = "eastus"
+}
+
 variable "min_replicas" {
   type        = number
   description = "Minimum replicas. 0 = cheapest (guests may hit a cold start); set default to 1 here to keep prod warm (~$3-14/mo)."

--- a/infra/terraform/modules/env-stack/main.tf
+++ b/infra/terraform/modules/env-stack/main.tf
@@ -7,7 +7,7 @@ data "azurerm_resource_group" "env" {
 # database (a Consumption-only env cannot add those later).
 resource "azurerm_container_app_environment" "this" {
   name                       = "cae-czw-${var.environment}"
-  location                   = data.azurerm_resource_group.env.location
+  location                   = var.location != "" ? var.location : data.azurerm_resource_group.env.location
   resource_group_name        = data.azurerm_resource_group.env.name
   log_analytics_workspace_id = var.log_analytics_workspace_id
 

--- a/infra/terraform/modules/env-stack/variables.tf
+++ b/infra/terraform/modules/env-stack/variables.tf
@@ -8,6 +8,12 @@ variable "resource_group_name" {
   description = "Pre-existing (bootstrap-created) resource group for this environment."
 }
 
+variable "location" {
+  type        = string
+  description = "Region for the Container App Environment. Empty = same region as the resource group. Set staging and production to different regions to satisfy the free-trial limit of 1 environment per region."
+  default     = ""
+}
+
 variable "log_analytics_workspace_id" {
   type        = string
   description = "Shared Log Analytics workspace ID (from the shared stack)."


### PR DESCRIPTION
Free-trial subscriptions allow only one Container App Environment per region; staging holds the Central US slot. Production now defaults to East US (env-stack gained an optional location override). Cross-region Log Analytics reference is supported.