### PR TITLE
Resize hero image + add CI image-size guardrail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run lint
+      - run: npm run check:images
       - run: npm run build
       - name: Docker build (no push)
         run: docker build -t czw:ci .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,9 @@ This file provides guidance to AI coding agents (Claude Code, Copilot, etc.) wor
 - `npm run build` — production build; must pass with zero errors before any PR
 - `npm run lint` — ESLint (`eslint-config-next`); add `--fix` to auto-correct
 - `npm run start` — run production build
+- `npm run check:images` — fails if any file under `public/images` exceeds size/dimension thresholds (`scripts/check-image-sizes.mjs`); CI-enforced
 
-There is no test suite. Validate app changes with `npm run build` and `npm run lint`.
+There is no test suite. Validate app changes with `npm run build`, `npm run lint`, and `npm run check:images`.
 
 For changes under `infra/terraform/`, CI additionally enforces `terraform fmt -check -recursive infra/terraform` and, per environment, `terraform -chdir=infra/terraform/environments/<env> init -backend=false && terraform validate`. Workflow file changes are checked with `actionlint`.
 

--- a/docs/superpowers/plans/2026-07-14-hero-image-guardrail.md
+++ b/docs/superpowers/plans/2026-07-14-hero-image-guardrail.md
@@ -1,0 +1,239 @@
+# Hero Image Resize + Size Guardrail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Resize the 20 MB hero background image to a web-appropriate size, and add a permanent, CI-enforced guardrail so an oversized image can never be committed to `public/images` again.
+
+**Architecture:** A committed guardrail script (`scripts/check-image-sizes.mjs`) checks every file under `public/images` against width/height/file-size thresholds using the `image-size` library. It's written and wired into `npm`/CI *first*, against the current 20 MB file, so it visibly fails — that failure is the proof the check works. Then a throwaway script (not committed) uses the `sharp` library already present in `node_modules` to resize the hero image in place, after which the guardrail passes.
+
+**Tech Stack:** Node.js (`fs`, `path` built-ins), `image-size` (new devDependency, dimension reads only), `sharp` (already present transitively via `next`, used only for the one-off resize, never imported by committed code), GitHub Actions (existing `ci.yml`).
+
+## Global Constraints
+
+- `MAX_WIDTH_PX = 2600`, `MAX_HEIGHT_PX = 2600`, `MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024` (1 MiB) — exact thresholds from the spec.
+- Resize target: 2560px wide, JPEG mozjpeg quality ~82, EXIF stripped, auto-rotated per original EXIF orientation before stripping.
+- No new dependency for the one-off resize (`sharp` already present via `next`'s optional dependency). Exactly one new devDependency for the permanent guardrail (`image-size`).
+- `npm run build` must pass with zero errors; `npm run lint` must pass, before any task is considered done (per project `CLAUDE.md`).
+- Full repo path: `/Users/aczarnick/personal/repos/wedding-website`.
+
+---
+
+### Task 1: Guardrail script (written and proven against the current oversized file)
+
+**Files:**
+- Create: `scripts/check-image-sizes.mjs`
+- Modify: `package.json` (add `check:images` script and `image-size` devDependency)
+
+**Interfaces:**
+- Produces: an executable script at `scripts/check-image-sizes.mjs`, runnable as `node scripts/check-image-sizes.mjs`, exit code 0 on success / 1 on any violation. Later tasks (2 and 3) invoke it via `npm run check:images` and rely on this exit-code contract.
+
+- [ ] **Step 1: Install the new devDependency**
+
+Run: `npm install --save-dev image-size@^2.0.2`
+
+Expected: `package.json` gains `"image-size": "^2.0.2"` under `devDependencies`, and `package-lock.json` is updated.
+
+- [ ] **Step 2: Write the guardrail script**
+
+Create `scripts/check-image-sizes.mjs`:
+
+```js
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { imageSizeFromFile } from 'image-size/fromFile';
+
+const IMAGES_DIR = 'public/images';
+const MAX_WIDTH_PX = 2600;
+const MAX_HEIGHT_PX = 2600;
+const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024;
+
+const toMiB = (bytes) => (bytes / 1024 / 1024).toFixed(2);
+
+async function checkImage(filePath) {
+  const violations = [];
+  const { size } = statSync(filePath);
+  const { width, height } = await imageSizeFromFile(filePath);
+
+  if (width > MAX_WIDTH_PX || height > MAX_HEIGHT_PX) {
+    violations.push(
+      `${filePath}: ${width}x${height}px exceeds ${MAX_WIDTH_PX}x${MAX_HEIGHT_PX}px`
+    );
+  }
+  if (size > MAX_FILE_SIZE_BYTES) {
+    violations.push(
+      `${filePath}: ${toMiB(size)} MiB exceeds ${toMiB(MAX_FILE_SIZE_BYTES)} MiB`
+    );
+  }
+  return violations;
+}
+
+const files = readdirSync(IMAGES_DIR).map((name) => join(IMAGES_DIR, name));
+const results = await Promise.all(files.map(checkImage));
+const violations = results.flat();
+
+if (violations.length > 0) {
+  console.error('Image size check failed:');
+  for (const violation of violations) {
+    console.error(`  - ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Image size check passed (${files.length} file(s) checked).`);
+```
+
+- [ ] **Step 3: Add the npm script**
+
+In `package.json`, add to `"scripts"`:
+
+```json
+"check:images": "node scripts/check-image-sizes.mjs"
+```
+
+- [ ] **Step 4: Run it and verify it FAILS against the current 20 MB file**
+
+Run: `npm run check:images`
+
+Expected output (exit code 1):
+
+```
+Image size check failed:
+  - public/images/trees-handhold.jpg: 6720x4480px exceeds 2600x2600px
+  - public/images/trees-handhold.jpg: 20.50 MiB exceeds 1.00 MiB
+```
+
+This is the proof the guardrail actually detects the problem it's meant to catch — equivalent to a failing test before the fix.
+
+- [ ] **Step 5: Lint the new script**
+
+Run: `npm run lint`
+
+Expected: no errors. If ESLint flags anything (e.g. Node globals), fix in `scripts/check-image-sizes.mjs` directly — do not add an ESLint ignore for the file.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json package-lock.json scripts/check-image-sizes.mjs
+git commit -m "Add image size guardrail script (fails on current oversized hero image)"
+```
+
+---
+
+### Task 2: Resize the hero image
+
+**Files:**
+- Modify (binary): `public/images/trees-handhold.jpg`
+- Create then delete (throwaway, never committed): `resize-hero.tmp.mjs` at the repo root
+
+**Interfaces:**
+- Consumes: `npm run check:images` from Task 1 (exit code contract) to verify success.
+- Produces: `public/images/trees-handhold.jpg` at 2560px wide, under 1 MiB — the file Task 3's CI wiring will validate on every future PR.
+
+- [ ] **Step 1: Write the throwaway resize script**
+
+Create `resize-hero.tmp.mjs` at the repo root (placed here, not in the scratchpad, so the bare `sharp` import resolves against the project's own `node_modules` without needing an absolute path):
+
+```js
+import sharp from 'sharp';
+
+const SOURCE = 'public/images/trees-handhold.jpg';
+const TARGET_WIDTH = 2560;
+
+await sharp(SOURCE)
+  .rotate() // auto-orient per EXIF before stripping metadata
+  .resize({ width: TARGET_WIDTH })
+  .jpeg({ quality: 82, mozjpeg: true })
+  .toFile(SOURCE + '.tmp');
+
+console.log('Resized. Replacing original...');
+```
+
+Note: `sharp` can't read from and write to the same path in one pipeline, hence the `.tmp` suffix.
+
+- [ ] **Step 2: Run it**
+
+Run: `node resize-hero.tmp.mjs && mv public/images/trees-handhold.jpg.tmp public/images/trees-handhold.jpg`
+
+Expected: script prints `Resized. Replacing original...` and the `.tmp` file is moved into place with no error.
+
+- [ ] **Step 3: Verify size and dimensions on disk**
+
+Run: `file public/images/trees-handhold.jpg && ls -la public/images/trees-handhold.jpg`
+
+Expected: `JPEG image data, ... 2560x1707` (or similar 2560-wide, EXIF-orientation-corrected dimensions, no Exif/TIFF block reported by `file` since metadata was stripped), and file size well under 1 MiB (a few hundred KB expected).
+
+- [ ] **Step 4: Run the guardrail and verify it now PASSES**
+
+Run: `npm run check:images`
+
+Expected:
+
+```
+Image size check passed (3 file(s) checked).
+```
+
+- [ ] **Step 5: Delete the throwaway resize script and confirm it's gone**
+
+Run: `rm resize-hero.tmp.mjs && git status --short`
+
+Expected: `resize-hero.tmp.mjs` does not appear in `git status` output (it never gets staged or committed — it's a one-off tool, not part of the codebase). Only `public/images/trees-handhold.jpg` should show as modified.
+
+- [ ] **Step 6: Build and visually verify in a browser**
+
+Run: `npm run build && npm run dev`
+
+Then open `http://localhost:3000` in a browser (or use `claude-in-chrome` tooling) at both a desktop width (e.g. 1440px) and a mobile width (e.g. 390px). Confirm:
+- The hero image renders immediately (no long blank-area delay before the image appears).
+- The image is crisp, not pixelated or blurry, at both widths.
+- No layout shift or distortion compared to before the resize.
+
+Stop the dev server afterward.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add public/images/trees-handhold.jpg
+git commit -m "Resize hero image from 20MB/6720x4480 to ~2560px wide, strip EXIF"
+```
+
+---
+
+### Task 3: Wire the guardrail into CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+**Interfaces:**
+- Consumes: `npm run check:images` (Task 1).
+
+- [ ] **Step 1: Add the CI step**
+
+In `.github/workflows/ci.yml`, in the `app` job, add a step after `npm run lint` and before `npm run build`:
+
+```yaml
+      - run: npm run lint
+      - run: npm run check:images
+      - run: npm run build
+```
+
+- [ ] **Step 2: Verify the full local sequence matches CI**
+
+Run: `npm ci && npm run lint && npm run check:images && npm run build`
+
+Expected: all four commands exit 0, in that order, with no manual intervention.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "Enforce image size guardrail in CI"
+```
+
+---
+
+## Definition of Done (post-implementation)
+
+Per the user's request, implementation is not complete until:
+1. All three tasks above are committed with passing verification steps.
+2. The work is reviewed by multiple independent agents (dispatch via the `code-review` skill and at least one additional independent review pass) and any findings are triaged/addressed.
+3. Tests exist: satisfied by `scripts/check-image-sizes.mjs` as a CI-enforced regression check (per the spec's Testing section — this repo has no test runner, so this script *is* the test).

--- a/docs/superpowers/specs/2026-07-14-hero-image-guardrail-design.md
+++ b/docs/superpowers/specs/2026-07-14-hero-image-guardrail-design.md
@@ -1,0 +1,58 @@
+# Hero image resize + size guardrail
+
+Ticket: [#32](https://github.com/aczarnick/wedding-website/issues/32) — Resize `trees-handhold.jpg` (20 MB, 6720×4480) to a web-appropriate size.
+
+## Problem
+
+`public/images/trees-handhold.jpg`, the hero background on the landing page, is 20 MB at 6720×4480. `next/image` serves optimized AVIF/WebP derivatives to the browser, but the optimizer must decode the full 20 MB source on every cold request, which is slow and memory-hungry on a small container, and the hero renders as a blank area while loading. It's also 20 MB of dead weight in the repo. There is currently no automated guard against this recurring (both other images in `public/images` are already reasonably sized, but nothing stops a future oversized image from being committed).
+
+## Scope
+
+1. Resize the source image in place to a web-appropriate size.
+2. Add a permanent, CI-enforced guardrail script so an oversized image can't be committed again.
+3. Wire the guardrail into `npm run` scripts and CI.
+
+Out of scope: adding a formal test runner (vitest/RTL) for the wider project — tracked separately in issue #36. Not pulling that in here; the guardrail script is a plain Node script, not a test-runner test.
+
+## Design
+
+### 1. One-off resize
+
+- Tool: `sharp`, already present in `node_modules` as an optional (transitive) dependency of `next` itself (used for Next's own image optimizer). No new dependency needed for this step.
+- Run via a throwaway Node script (not committed — written to the scratchpad, executed once, then deleted).
+- Transform: auto-rotate per EXIF orientation, strip all metadata (EXIF/GPS/camera info — also a minor privacy win), resize to 2560px wide (matches the hero's `sizes="100vw"` usage on large desktop viewports, per Next's own image device-size breakpoints), re-encode as JPEG with mozjpeg at quality ~82.
+- Output overwrites `public/images/trees-handhold.jpg` in place.
+- Expected result: well under 1 MB, comparable to the repo's other two images (`lift-bar.jpg` 273 KB, `ring-shot.jpg` 193 KB, both 1024×1536).
+
+### 2. Guardrail script (permanent)
+
+New file: `scripts/check-image-sizes.mjs`.
+
+- Scans all files under `public/images/**`.
+- For each file, reads:
+  - byte size via Node's built-in `fs.statSync`
+  - pixel width/height via a new devDependency, `image-size` — a small, pure-JS library that parses just the image header (no native binaries), appropriate for a dimensions-only check as opposed to pulling in `sharp` (a heavy multi-platform native image-processing library) as an explicit dependency just to read a width/height.
+- Thresholds, as named constants at the top of the script:
+  - `MAX_WIDTH_PX = 2600`
+  - `MAX_HEIGHT_PX = 2600`
+  - `MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024` (1 MiB)
+  - (Buffer above the 2560px resize target / expected few-hundred-KB output; both existing images at 1024×1536 pass comfortably today.)
+- Behavior: check every file, collect *all* violations (don't stop at the first), print them, and `process.exit(1)` if any exist; otherwise print a success line and exit 0.
+- Error handling: a corrupt/unreadable image should fail loud — let `image-size`'s parse error propagate rather than being swallowed.
+
+### 3. Wiring
+
+- `package.json`: add `"check:images": "node scripts/check-image-sizes.mjs"`.
+- `.github/workflows/ci.yml`: add a step in the `app` job, after `npm run lint` and before `npm run build`.
+
+## Testing
+
+This ticket is an asset change with no application logic, so "tests written" is satisfied by the guardrail script itself:
+
+- The guardrail script is the automated, CI-enforced check — it runs on every PR from now on and would have caught the original 20 MB file. It's the regression test for this class of bug.
+- Manual verification (not automated, but required before calling this done): confirm the resized file's size/dimensions on disk, run `npm run build`, and visually check the hero renders crisply on both desktop and mobile widths in a browser.
+
+## Alternatives considered
+
+- **`sharp` as an explicit devDependency for both resize and guardrail.** Rejected: promotes a multi-platform native binary package to an explicit, CI-required dependency just to read image dimensions, which is heavier than the job requires. `image-size` is a tiny, purpose-built alternative for the read-only check.
+- **macOS `sips` for the resize + a hand-rolled JPEG/PNG header parser for the guardrail (zero new dependencies).** Rejected: `sips` is macOS-only and not reproducible on Linux CI or by other contributors if this ever needs to be redone; hand-rolling an image header parser reinvents what a small, well-maintained library (`image-size`) already does correctly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,7 +72,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -282,10 +281,32 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
-      "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1590,7 +1611,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1650,7 +1670,6 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -2176,7 +2195,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2517,7 +2535,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3085,7 +3102,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3271,7 +3287,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5470,7 +5485,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5480,7 +5494,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6169,7 +6182,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6332,7 +6344,6 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6608,7 +6619,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "16.2.10",
+        "image-size": "^2.0.2",
         "playwright-core": "^1.61.1",
         "tailwindcss": "^4",
         "typescript": "^6"
@@ -71,6 +72,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -278,28 +280,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
-      "integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
-      "integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -1469,27 +1449,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
       "version": "1.2.2",
       "dev": true,
@@ -1631,6 +1590,7 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1690,6 +1650,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -2215,6 +2176,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2555,6 +2517,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3122,6 +3085,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3307,6 +3271,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3994,6 +3959,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/import-fresh": {
@@ -5492,6 +5470,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
       "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5501,6 +5480,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
       "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -6189,6 +6169,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6351,6 +6332,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6626,6 +6608,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "check:images": "node scripts/check-image-sizes.mjs"
   },
   "dependencies": {
     "next": "^16.2.10",
@@ -20,6 +21,7 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "16.2.10",
+    "image-size": "^2.0.2",
     "playwright-core": "^1.61.1",
     "tailwindcss": "^4",
     "typescript": "^6"

--- a/scripts/check-image-sizes.mjs
+++ b/scripts/check-image-sizes.mjs
@@ -1,0 +1,42 @@
+import { readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import { imageSizeFromFile } from 'image-size/fromFile';
+
+const IMAGES_DIR = 'public/images';
+const MAX_WIDTH_PX = 2600;
+const MAX_HEIGHT_PX = 2600;
+const MAX_FILE_SIZE_BYTES = 1 * 1024 * 1024;
+
+const toMiB = (bytes) => (bytes / 1024 / 1024).toFixed(2);
+
+async function checkImage(filePath) {
+  const violations = [];
+  const { size } = statSync(filePath);
+  const { width, height } = await imageSizeFromFile(filePath);
+
+  if (width > MAX_WIDTH_PX || height > MAX_HEIGHT_PX) {
+    violations.push(
+      `${filePath}: ${width}x${height}px exceeds ${MAX_WIDTH_PX}x${MAX_HEIGHT_PX}px`
+    );
+  }
+  if (size > MAX_FILE_SIZE_BYTES) {
+    violations.push(
+      `${filePath}: ${toMiB(size)} MiB exceeds ${toMiB(MAX_FILE_SIZE_BYTES)} MiB`
+    );
+  }
+  return violations;
+}
+
+const files = readdirSync(IMAGES_DIR).map((name) => join(IMAGES_DIR, name));
+const results = await Promise.all(files.map(checkImage));
+const violations = results.flat();
+
+if (violations.length > 0) {
+  console.error('Image size check failed:');
+  for (const violation of violations) {
+    console.error(`  - ${violation}`);
+  }
+  process.exit(1);
+}
+
+console.log(`Image size check passed (${files.length} file(s) checked).`);


### PR DESCRIPTION
## Summary
- Resizes `public/images/trees-handhold.jpg` from 20.5 MB / 6720x4480 to ~715 KB / 2560x1707 (EXIF stripped, aspect ratio preserved), fixing slow cold-request image optimization and a blank hero on load.
- Adds a permanent, CI-enforced guardrail (`scripts/check-image-sizes.mjs`, `npm run check:images`) that fails if any file under `public/images` exceeds 2600px width/height or 1 MiB — proven to fail against the original oversized file before the fix, and passing now.
- Wires the guardrail into `.github/workflows/ci.yml` between lint and build.
- Updates `AGENTS.md` to document the new `check:images` validation command.

Design spec and implementation plan are included under `docs/superpowers/`.

Closes #32.

## Review
Implemented via subagent-driven development: 3 task-level reviews (one fix round for an npm-version lockfile mismatch), a whole-branch review, and an independent second review pass. All findings resolved except two accepted Minor items (non-recursive image scan given today's flat directory; a redundant JPEG re-encode quality note) — deferred as low-risk per the design's stated scope.

## Test plan
- [x] `npm run check:images` fails against the original 20.5 MB file, passes after resize
- [x] `npm run lint` — zero errors
- [x] `npm run build` — zero errors
- [x] Hero verified in browser at desktop (1440px) and mobile (390px) widths — renders promptly, crisp, no layout shift
- [x] CI workflow updated and dry-run verified locally (`npm ci && npm run lint && npm run check:images && npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)