### PR TITLE
Align eslint-config-next with next (#34)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "eslint": "^9",
-        "eslint-config-next": "16.2.10",
+        "eslint-config-next": "^16.2.10",
         "image-size": "^2.0.2",
         "playwright-core": "^1.61.1",
         "tailwindcss": "^4",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
-    "eslint-config-next": "16.2.10",
+    "eslint-config-next": "^16.2.10",
     "image-size": "^2.0.2",
     "playwright-core": "^1.61.1",
     "tailwindcss": "^4",


### PR DESCRIPTION
Closes #34

## Plan
The version bump (16.1.3 → 16.2.10) already landed via Dependabot (#26), so the two packages match today. This PR fixes the *root cause*: `eslint-config-next` was pinned **exact** (`16.2.10`) while `next` uses a caret (`^16.2.10`). Because these packages are released in lockstep, an exact pin lets them silently drift apart on the next `next` bump — and it's why Dependabot didn't keep them aligned in the first place. Switching to `^16.2.10` makes the alignment self-maintaining and matches the repo's dominant caret convention. Lockfile regenerated with `npm@10` to match CI.

## Verification
`npm run lint && npm run build && npm run check:images` — all pass. Lockfile diff is a clean spec-only update (no dependency changes).

## Code review
`/code-review high --fix` — no findings. One-character hardening with no runtime surface; nothing to fix or leave open.
