### PR TITLE
CI: read Node version from .nvmrc instead of a literal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
-          node-version: 24
+          node-version-file: '.nvmrc'
           cache: npm
       - run: npm ci
       - run: npm run lint


### PR DESCRIPTION
## What
Point `actions/setup-node` at `node-version-file: '.nvmrc'` instead of the hardcoded `node-version: 24`.

## Why
The Node 24 standardization (#30, merged in #53) added `.nvmrc` (24) but left `ci.yml` with a literal `node-version: 24` right next to it — two sources of truth for the run-version, the exact drift #30 set out to remove. With `node-version-file`, `.nvmrc` is the single source: a future Node bump touches one file.

No functional change — `.nvmrc` containing `24` resolves to the same latest-24.x that `node-version: 24` did. Follow-up split out from #53 (that PR was already merged).

## Verification
`actionlint` passes locally; CI on this PR exercises the change (setup-node resolving Node from `.nvmrc`).
