### PR TITLE
Cloudflare custom domains + TLS for ACA, fully in Terraform

### DIFF
--- a/.github/workflows/_terraform-env.yml
+++ b/.github/workflows/_terraform-env.yml
@@ -46,6 +46,9 @@ jobs:
       # Origin lock lives in a repo variable, not a gitignored tfvars, so the
       # pipeline never reverts it. Defaults to [] (open) until you set it.
       TF_VAR_allowed_ip_ranges: ${{ vars.ALLOWED_IP_RANGES_JSON || '[]' }}
+      # Cloudflare provider auth — a single zone-scoped API token; required
+      # scopes documented in docs/deployment/README.md (Custom domains).
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
     steps:
       - uses: actions/checkout@v7
       - uses: hashicorp/setup-terraform@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,4 +65,4 @@ Environment variables that CI passes come from GitHub repo variables (e.g. `ACR_
 
 ### Cost guardrails (pay-as-you-go, no hard cap)
 
-Spend is bounded structurally, not by a spending limit: scale-to-zero (`min_replicas=0`), capped `max_replicas` (staging 1, production 2), ACR Basic, Log Analytics 1 GB/day quota, Cloudflare proxy in front, plus budget email alerts. Don't add premium SKUs or raise replica caps without flagging the cost implication.
+Spend is bounded structurally, not by a spending limit: staging scales to zero (`min_replicas=0`), production keeps one warm replica (`min_replicas=1`, deliberate — no guest-facing cold starts, ~$3–14/mo), capped `max_replicas` (staging 1, production 2), ACR Basic, Log Analytics 1 GB/day quota, Cloudflare proxy in front, plus budget email alerts. Don't add premium SKUs or raise replica caps without flagging the cost implication.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -113,36 +113,50 @@ waits for your approval.
 
 ## Custom domains, TLS, and Cloudflare
 
-Do this once per host (`czarnickwedding.com`, `www`, `staging`). Get each app's
-values from Terraform outputs:
+Terraform manages all of it: Cloudflare DNS (proxied host records + `asuid.*`
+verification TXTs), zone SSL mode **Full (strict)**, a 15-year **Cloudflare
+Origin CA certificate** (issued in `shared`, uploaded and SNI-bound in each
+environment), and the Container App hostname bindings. The committed hostname
+sets live in each env root's `custom_domains` variable default.
 
-```bash
-cd infra/terraform/environments/production   # or staging
-terraform output -raw custom_domain_verification_id
-terraform output -raw default_fqdn            # sensitive (origin) — -raw to reveal
-terraform output -raw environment_static_ip   # sensitive (origin) — -raw to reveal
-```
+One GitHub **secret** feeds the provider (also export it for local applies):
 
-1. **Cloudflare DNS — start DNS-only (grey cloud)** so ACA can validate cleanly:
-   - `www` / `staging`: **CNAME** → the app's `default_fqdn`.
-   - apex `czarnickwedding.com`: **A** → the app's `environment_static_ip`.
-   - For each host add **TXT** `asuid.<host>` = the app's
-     `custom_domain_verification_id`.
-2. **Bind the domain** to the app (portal → Container App → Custom domains, or
-   `az containerapp hostname add`).
-3. **Certificate — use a Cloudflare Origin CA certificate** (do NOT use the ACA
-   free managed cert: it silently fails to renew behind the Cloudflare proxy).
-   Create an Origin cert in Cloudflare (covers `czarnickwedding.com` +
-   `*.czarnickwedding.com`), then upload and bind it in **each** environment
-   separately — `cae-czw-staging` and `cae-czw-production` are distinct ACA
-   environments (`az containerapp hostname bind` / portal).
-4. **Turn the Cloudflare proxy ON (orange cloud)** and set SSL/TLS mode to
-   **Full (strict)**. This gives caching/WAF/DDoS protection and absorbs traffic
-   spikes — a cost control, not just security.
-5. **Lock the origin.** Set the Cloudflare IP ranges as a **GitHub repo
-   variable** `ALLOWED_IP_RANGES_JSON` (NOT a local `terraform.tfvars` — the
-   pipeline would revert that), then re-run the Infra workflow. Only Cloudflare
-   can then reach ACA. Value (verify current list at https://www.cloudflare.com/ips/):
+- `CLOUDFLARE_API_TOKEN` — a single zone-scoped token: **Zone:Read, DNS:Edit,
+  Zone Settings:Edit, and SSL and Certificates:Edit** on the zone. The last
+  permission covers Origin CA certificate issuance — do NOT also configure an
+  Origin CA key: the provider forbids dual credentials, and Origin CA keys are
+  deprecated (Cloudflare removes them 2026-09-30).
+
+Notes:
+
+- The ACA **free managed cert is deliberately not used** — it silently fails to
+  renew behind the Cloudflare proxy. The Origin CA cert is trusted only by
+  Cloudflare, which is exactly the trust path in use.
+- The Origin CA **private key (and certificate) live in Terraform state**
+  (AAD-locked storage account) — accepted trade-off, see
+  `docs/superpowers/specs/2026-07-10-cloudflare-custom-domain-tls-design.md`.
+  The provider credentials themselves are env-var-only and never persisted to
+  state.
+- Hostname ownership is validated via the `asuid.*` TXT records, so records can
+  stay **proxied (orange) the whole time**.
+- Cert rotation before 2041: taint `tls_private_key.origin` in `shared` and
+  re-apply shared → staging → production. The env cert resource is
+  create-before-destroy with a fingerprint-suffixed name, so the new cert
+  exists before the old one is removed; the hostname bindings switch during
+  each env apply (do it in a quiet moment — the binding switch may blip).
+
+### Origin lock + smoke hosts (after DNS is live)
+
+1. Set repo variables `STAGING_SMOKE_HOST=staging.czarnickwedding.com` and
+   `PRODUCTION_SMOKE_HOST=czarnickwedding.com` so deploy smoke tests go through
+   Cloudflare. Set them as soon as the public hostnames serve — mandatory
+   before the origin lock, or the next deploy's smoke test hits the
+   now-blocked default FQDNs and fails.
+
+2. Set repo variable `ALLOWED_IP_RANGES_JSON` to the Cloudflare ranges (verify
+   at https://www.cloudflare.com/ips/) and re-run Infra. Only Cloudflare can
+   then reach the ACA default FQDNs. Don't use a local `terraform.tfvars` — the
+   pipeline would revert it:
 
    ```
    [{"name":"cf01","cidr":"173.245.48.0/20"},{"name":"cf02","cidr":"103.21.244.0/22"},
@@ -155,14 +169,22 @@ terraform output -raw environment_static_ip   # sensitive (origin) — -raw to r
     {"name":"cf15","cidr":"131.0.72.0/22"}]
    ```
 
-6. **Point smoke tests through Cloudflare.** Once the origin is IP-locked, GitHub
-   runners can no longer reach the default ACA FQDN. Set repo variables
-   `STAGING_SMOKE_HOST=staging.czarnickwedding.com` and
-   `PRODUCTION_SMOKE_HOST=czarnickwedding.com` so deploys smoke-test through the
-   public hostnames. (Leave them unset until the origin lock is in place.)
+   IPv4 ranges only, deliberately: the origin is reached via the IPv4
+   environment static IP, so Cloudflare's IPv6 egress ranges never apply here.
 
-   Optional hardening: enable Cloudflare **Authenticated Origin Pull** (mTLS) for
-   a stronger origin lock than IP allow-listing alone.
+Optional hardening: Cloudflare **Authenticated Origin Pull** (mTLS) for a
+stronger origin lock than IP allow-listing alone.
+
+### One-time apex cutover (2026-07, for the record)
+
+The apex previously served from a home server via Cloudflare Tunnel. Cutover
+was: bind apex+www while the apex record still pointed at the tunnel (TXT
+validation), verify `www` end-to-end, then flip the apex record to the
+environment static IP (`terraform import` + apply, or an atomic dashboard edit
+when the plan would replace rather than update). A targeted apply
+(`-target=module.stack.azurerm_container_app_custom_domain.this ...`) was used
+once to stage bindings before DNS — do not reach for `-target` in normal
+operation.
 
 ## Rollback
 
@@ -171,14 +193,15 @@ Single revision mode → roll back by redeploying a known-good image:
 `<acr>.azurecr.io/web@sha256:<digest>` or `<acr>.azurecr.io/web:<old-sha>`. It
 skips the build and redeploys that exact image through staging → production.
 
-## Keeping prod warm (optional)
+## Keeping prod warm
 
-Guests hitting a scaled-to-zero app pay a one-time cold start (~seconds). To
-avoid it, change the **committed** default `min_replicas = 1` in
+Production's committed default is `min_replicas = 1` (~$3–14/mo) so guests
+never hit a scale-from-zero cold start (~20–30 s). To go back to the cheapest
+setup, change the committed default back to `0` in
 `infra/terraform/environments/production/variables.tf` and let the Infra
-pipeline apply it (~$3–14/mo). Don't use a local `terraform.tfvars` — the
-pipeline only passes the repo-variable-backed vars, so a tfvars override would be
-reverted on the next apply.
+pipeline apply it. Don't use a local `terraform.tfvars` — the pipeline only
+passes the repo-variable-backed vars, so a tfvars override would be reverted on
+the next apply.
 
 ## Teardown
 

--- a/docs/superpowers/plans/2026-07-10-cloudflare-custom-domain-tls.md
+++ b/docs/superpowers/plans/2026-07-10-cloudflare-custom-domain-tls.md
@@ -1,0 +1,793 @@
+# Cloudflare Custom Domains + TLS Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Serve `czarnickwedding.com`, `www`, and `staging` through the Cloudflare proxy (Full strict) from the Azure Container Apps, all managed by Terraform, with the origin IP-locked to Cloudflare and smoke tests routed through the public hostnames (GitHub issue #23).
+
+**Architecture:** Extend the existing `shared → staging → production` Terraform roots. `shared` issues one Cloudflare Origin CA certificate (apex + wildcard) and sets zone SSL to strict; the `env-stack` module gains optional custom-domain inputs that create per-env DNS records, cert upload, and hostname bindings. The live apex record (currently a Cloudflare Tunnel to a home server, carrying guest traffic) is cut over zero-downtime via a targeted apply + import.
+
+**Tech Stack:** Terraform ≥1.9, azurerm ~>4.0, cloudflare ~>5 (v5 schemas!), hashicorp/tls ~>4, GitHub Actions, `az`/`gh` CLIs.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-cloudflare-custom-domain-tls-design.md`
+
+**Post-review amendments (2026-07-14):** Part A was implemented and code-reviewed; the as-built code differs from the task snippets below in these ways: host-record `content` wrapped in `sensitive()` (origin IP/FQDN out of public plan logs); TXT content pre-quoted (`"\"...\""`); env cert has `create_before_destroy` + fingerprint-suffixed name (safe rotation); module custom-domain variables are required (no empty defaults, `custom_domains=[]` is the opt-out) and the `zone_id != ""` gate is gone; no `provider "cloudflare"` blocks in staging/production roots; orphaned `custom_domain_verification_id`/`environment_static_ip` outputs removed from env roots + env-stack. Auth is **token-only** (2nd review round): Origin CA keys are deprecated by Cloudflare (removed 2026-09-30) and the provider forbids dual credentials — `CLOUDFLARE_API_USER_SERVICE_KEY` is gone from the workflow and Task 8; the token's SSL and Certificates:Edit covers Origin CA issuance. Shared cert chain got `create_before_destroy`; module `custom_domains` is `set(string)` (no locals); module providers are version-pinned. Part B expected-plan descriptions still hold.
+
+## Global Constraints
+
+- **NO git commits and NO PRs** — the user commits/PRs after review. Task boundaries end at verification, not commit. (Deviation from the usual plan style, per explicit user instruction.)
+- All work happens in the worktree `.claude/worktrees/issue-23-cloudflare-domains` (branch `worktree-issue-23-cloudflare-domains`, based on `origin/master` @ `6ff83cd`).
+- Verification gate for repo changes (from `AGENTS.md`): `terraform fmt -check -recursive infra/terraform`; per env `terraform -chdir=infra/terraform/environments/<env> init -backend=false && terraform validate`; `actionlint` for workflow changes.
+- `.terraform.lock.hcl` files are committed artifacts — regenerate them with hashes for `linux_amd64` (CI) **and** `darwin_arm64` (local applies).
+- Cloudflare provider is **v5**: resources are `cloudflare_dns_record` (not `cloudflare_record`), `cloudflare_zone_setting`, data `cloudflare_zone` uses `filter = { name = ... }`.
+- Provider auth is env-var only, never in HCL: a single `CLOUDFLARE_API_TOKEN` (Zone:Read + DNS:Edit + Zone Settings:Edit + SSL and Certificates:Edit on the zone; the last covers Origin CA issuance).
+- The apex serves live guest traffic from the old origin until Task 11 — nothing before Task 11 may modify the existing apex DNS record.
+- Known live values: subscription `39aaecb8-c5d9-4cd4-9dab-125353808a9b`, state account `czwtfstate17540`, ACR `czwacr11821`, budget start `2026-08-01T00:00:00Z`, staging env static IP `52.154.166.48`, production env static IP `172.169.206.47`, prod default FQDN `ca-czw-production.whiteriver-ca9e24a5.centralus.azurecontainerapps.io`, staging default FQDN `ca-czw-staging.yellowforest-20879e09.centralus.azurecontainerapps.io`.
+- **Change freeze during Part B (Tasks 9–14):** local state runs ahead of `master`, so no merges to master and no manual Infra/Deploy dispatches except Task 13's. A master Infra run would fail loudly (missing cloudflare provider/creds), not destroy — but don't rely on it: Task 9 disables the Infra workflow, Task 14 re-enables it. **PR #24 (eslint bump) is open — hold it until this merges.**
+- **Execution shell model:** each Bash invocation gets a fresh shell — `export`/`cd` do NOT persist. Task 8 writes a `chmod 600` env file in the scratchpad; every Part B command is prefixed with `source "$ENVFILE" &&` and uses absolute `terraform -chdir=` paths (`WT=/Users/aczarnick/personal/repos/wedding-website/.claude/worktrees/issue-23-cloudflare-domains`).
+
+---
+
+## Part A — Repository changes (Tasks 1–7)
+
+### Task 1: Cloudflare + TLS providers in all roots and the env-stack module
+
+**Files:**
+- Modify: `infra/terraform/environments/shared/versions.tf`
+- Modify: `infra/terraform/environments/staging/versions.tf`
+- Modify: `infra/terraform/environments/production/versions.tf`
+- Create: `infra/terraform/modules/env-stack/versions.tf`
+
+**Interfaces:**
+- Produces: `cloudflare` provider available in all roots and inside `env-stack`; `tls` provider in `shared`.
+
+- [ ] **Step 1: Add providers to `shared/versions.tf`**
+
+Replace the `required_providers` block and append a provider block, keeping the existing azurerm provider block untouched:
+
+```hcl
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+  }
+}
+```
+
+Append after the azurerm provider block:
+
+```hcl
+# Auth via the CLOUDFLARE_API_TOKEN env var — a GitHub secret in CI, exported
+# locally; required scopes in docs/deployment/README.md. Never hardcode
+# credentials here.
+provider "cloudflare" {}
+```
+
+- [ ] **Step 2: Add cloudflare to `staging/versions.tf` and `production/versions.tf`**
+
+Same edit in both files: add to `required_providers` (no `tls` needed here):
+
+```hcl
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+```
+
+and append the same commented `provider "cloudflare" {}` block as in Step 1.
+
+- [ ] **Step 3: Create `modules/env-stack/versions.tf`**
+
+Modules using non-hashicorp providers must declare the source themselves:
+
+```hcl
+terraform {
+  required_providers {
+    azurerm = {
+      source = "hashicorp/azurerm"
+    }
+    cloudflare = {
+      source = "cloudflare/cloudflare"
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Regenerate lock files for both platforms**
+
+```bash
+for env in shared staging production; do
+  terraform -chdir=infra/terraform/environments/$env providers lock \
+    -platform=linux_amd64 -platform=darwin_arm64
+done
+```
+
+Expected: each `.terraform.lock.hcl` gains `cloudflare/cloudflare` (and `hashicorp/tls` for shared) entries with hashes for both platforms. Verify existing azurerm entries keep both platforms too (`grep -c h1: infra/terraform/environments/shared/.terraform.lock.hcl` — every provider should list multiple hashes). Run this AFTER Step 3 (env-stack's `versions.tf` must exist so staging/production lock cloudflare); if `providers lock` complains about uninstalled modules, run `terraform -chdir=... init -backend=false` first.
+
+- [ ] **Step 5: Verify**
+
+```bash
+terraform fmt -check -recursive infra/terraform
+for env in shared staging production; do
+  terraform -chdir=infra/terraform/environments/$env init -backend=false -input=false >/dev/null \
+    && terraform -chdir=infra/terraform/environments/$env validate
+done
+```
+
+Expected: fmt silent; three `Success! The configuration is valid.`
+
+### Task 2: Origin CA certificate, zone lookup, SSL strict in `shared`
+
+**Files:**
+- Create: `infra/terraform/environments/shared/cloudflare.tf`
+- Modify: `infra/terraform/environments/shared/variables.tf` (append)
+- Modify: `infra/terraform/environments/shared/outputs.tf` (append)
+
+**Interfaces:**
+- Produces (remote-state outputs consumed by Task 5): `cloudflare_zone_id` (string), `cloudflare_zone_name` (string), `origin_certificate_pem` (string), `origin_private_key_pem` (string, sensitive).
+
+- [ ] **Step 1: Append to `shared/variables.tf`**
+
+```hcl
+variable "cloudflare_zone_name" {
+  type        = string
+  description = "Cloudflare zone (the site's domain). Zone ID is looked up at plan time."
+  default     = "czarnickwedding.com"
+}
+```
+
+- [ ] **Step 2: Create `shared/cloudflare.tf`**
+
+```hcl
+data "cloudflare_zone" "site" {
+  filter = {
+    name = var.cloudflare_zone_name
+  }
+}
+
+# Cloudflare-to-origin TLS mode. "strict" requires the origin to present a
+# cert Cloudflare trusts — the Origin CA certificate below. Safe to enable
+# before the apex cutover: Cloudflare Tunnel traffic ignores this path.
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = data.cloudflare_zone.site.id
+  setting_id = "ssl"
+  value      = "strict"
+}
+
+# One Origin CA certificate (apex + wildcard) shared by both environments.
+# Trusted only by the Cloudflare edge, never by browsers. Deliberately NOT the
+# ACA free managed cert (it silently fails to renew behind the proxy). The
+# private key lives in Terraform state — the state account is AAD-locked.
+resource "tls_private_key" "origin" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_cert_request" "origin" {
+  private_key_pem = tls_private_key.origin.private_key_pem
+  dns_names       = [var.cloudflare_zone_name, "*.${var.cloudflare_zone_name}"]
+
+  subject {
+    common_name = var.cloudflare_zone_name
+  }
+}
+
+resource "cloudflare_origin_ca_certificate" "origin" {
+  csr                = tls_cert_request.origin.cert_request_pem
+  hostnames          = [var.cloudflare_zone_name, "*.${var.cloudflare_zone_name}"]
+  request_type       = "origin-rsa"
+  requested_validity = 5475 # 15 years — rotation is a manual re-apply, documented in the runbook
+}
+```
+
+Note: if `validate`/`plan` reports the zone data source has no `id` attribute, use `zone_id`. One of the two exists in v5 — check `terraform providers schema -json` if unsure.
+
+- [ ] **Step 3: Append to `shared/outputs.tf`**
+
+```hcl
+output "cloudflare_zone_id" {
+  value       = data.cloudflare_zone.site.id
+  description = "Cloudflare zone ID, consumed by the env stacks for DNS records."
+}
+
+output "cloudflare_zone_name" {
+  value       = var.cloudflare_zone_name
+  description = "Zone apex name — env stacks use it to pick A vs CNAME per hostname."
+}
+
+output "origin_certificate_pem" {
+  value       = cloudflare_origin_ca_certificate.origin.certificate
+  description = "Origin CA certificate (PEM), uploaded to each Container App Environment."
+}
+
+output "origin_private_key_pem" {
+  value       = tls_private_key.origin.private_key_pem
+  description = "Origin CA private key (PEM). Sensitive — lives only in state."
+  sensitive   = true
+}
+```
+
+- [ ] **Step 4: Verify** — same fmt/validate commands as Task 1 Step 5. Expected: pass.
+
+### Task 3: `id` output on the container-app module
+
+**Files:**
+- Modify: `infra/terraform/modules/container-app/outputs.tf` (append)
+
+**Interfaces:**
+- Produces: `module.app.id` (Container App resource ID) for the binding resource in Task 4.
+
+- [ ] **Step 1: Append to `outputs.tf`**
+
+```hcl
+output "id" {
+  value       = azurerm_container_app.this.id
+  description = "Container App resource ID (custom-domain bindings attach to it)."
+}
+```
+
+- [ ] **Step 2: Verify** — fmt/validate as before. Expected: pass.
+
+### Task 4: Custom-domain resources in the env-stack module
+
+**Files:**
+- Create: `infra/terraform/modules/env-stack/custom-domains.tf`
+- Modify: `infra/terraform/modules/env-stack/variables.tf` (append)
+
+**Interfaces:**
+- Consumes: `module.app.id`, `module.app.default_fqdn`, `module.app.custom_domain_verification_id` (existing + Task 3), `azurerm_container_app_environment.this` (existing).
+- Produces: DNS + binding resources at addresses `module.stack.cloudflare_dns_record.verification["<host>"]`, `module.stack.cloudflare_dns_record.host["<host>"]`, `module.stack.azurerm_container_app_environment_certificate.origin[0]`, `module.stack.azurerm_container_app_custom_domain.this["<host>"]` (exact addresses matter for Task 10/11 `-target`/`import`).
+
+- [ ] **Step 1: Append to `modules/env-stack/variables.tf`**
+
+```hcl
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID. Empty disables all custom-domain management."
+  default     = ""
+}
+
+variable "cloudflare_zone_name" {
+  type        = string
+  description = "Zone apex name. Hostnames equal to it get an A record to the environment static IP; others get a CNAME to the app FQDN."
+  default     = ""
+}
+
+variable "custom_domains" {
+  type        = list(string)
+  description = "Public hostnames to bind to the app (behind the Cloudflare proxy)."
+  default     = []
+}
+
+variable "origin_certificate_pem" {
+  type        = string
+  description = "Cloudflare Origin CA certificate (PEM), from the shared stack."
+  default     = ""
+}
+
+variable "origin_private_key_pem" {
+  type        = string
+  description = "Origin CA private key (PEM), from the shared stack."
+  default     = ""
+  sensitive   = true
+}
+```
+
+- [ ] **Step 2: Create `modules/env-stack/custom-domains.tf`**
+
+```hcl
+locals {
+  custom_domains = var.cloudflare_zone_id != "" ? toset(var.custom_domains) : toset([])
+}
+
+# Hostname-ownership TXT records. ACA validates via asuid.<host>, which keeps
+# working while the host record stays proxied (orange cloud) — that is what
+# makes the zero-downtime apex cutover possible.
+resource "cloudflare_dns_record" "verification" {
+  for_each = local.custom_domains
+
+  zone_id = var.cloudflare_zone_id
+  name    = "asuid.${each.value}"
+  type    = "TXT"
+  content = module.app.custom_domain_verification_id
+  ttl     = 1
+}
+
+# Cloudflare Origin CA cert for the environment. Deliberately not the ACA free
+# managed cert, which silently fails to renew behind the Cloudflare proxy.
+resource "azurerm_container_app_environment_certificate" "origin" {
+  count = length(local.custom_domains) > 0 ? 1 : 0
+
+  name                         = "cf-origin-${var.environment}"
+  container_app_environment_id = azurerm_container_app_environment.this.id
+  # trimspace + explicit newlines: a missing trailing newline between the two
+  # PEM blocks would produce an unparseable bundle (opaque ARM error).
+  certificate_blob_base64      = base64encode("${trimspace(var.origin_certificate_pem)}\n${trimspace(var.origin_private_key_pem)}\n")
+  certificate_password         = ""
+}
+
+resource "azurerm_container_app_custom_domain" "this" {
+  for_each = local.custom_domains
+
+  name                                     = each.value
+  container_app_id                         = module.app.id
+  container_app_environment_certificate_id = azurerm_container_app_environment_certificate.origin[0].id
+  certificate_binding_type                 = "SniEnabled"
+
+  # Ownership validation reads the asuid TXT record.
+  depends_on = [cloudflare_dns_record.verification]
+}
+
+# Proxied host records: apex -> A to the environment static IP; subdomains ->
+# CNAME to the app's default FQDN. Created only after the hostname is bound so
+# guests are never routed to an unbound host (ACA would 404).
+resource "cloudflare_dns_record" "host" {
+  for_each = local.custom_domains
+
+  zone_id = var.cloudflare_zone_id
+  name    = each.value
+  type    = each.value == var.cloudflare_zone_name ? "A" : "CNAME"
+  content = each.value == var.cloudflare_zone_name ? azurerm_container_app_environment.this.static_ip_address : module.app.default_fqdn
+  proxied = true
+  ttl     = 1
+
+  depends_on = [azurerm_container_app_custom_domain.this]
+}
+```
+
+Known wrinkles (decide on real plan/apply output, not preemptively):
+- Some cloudflare v5 releases require TXT `content` wrapped in escaped quotes (`"\"${...}\""`) and perma-diff otherwise. Task 14's `-detailed-exitcode` no-op check catches any perma-diff.
+- ACA accepts PEM cert+key bundles (`az containerapp env certificate upload` documents `.pfx` or `.pem`), but the first live proof is the **staging** apply (safe host). If ARM rejects the PEM there, fall back to a passwordless PFX (e.g. `chilicat/pkcs12` provider) — do not debug on production.
+
+- [ ] **Step 3: Verify** — fmt/validate as before. Expected: pass (module wiring completes in Task 5; defaults keep it inert).
+
+### Task 5: Wire the roots (staging + production) and warm prod
+
+**Files:**
+- Modify: `infra/terraform/environments/staging/main.tf`
+- Modify: `infra/terraform/environments/staging/variables.tf` (append)
+- Modify: `infra/terraform/environments/production/main.tf`
+- Modify: `infra/terraform/environments/production/variables.tf` (append + edit `min_replicas`)
+
+**Interfaces:**
+- Consumes: shared remote-state outputs from Task 2; module variables from Task 4.
+
+- [ ] **Step 1: Append to `staging/variables.tf`**
+
+```hcl
+variable "custom_domains" {
+  type        = list(string)
+  description = "Public hostnames bound to the staging app (behind the Cloudflare proxy)."
+  default     = ["staging.czarnickwedding.com"]
+}
+```
+
+- [ ] **Step 2: Add to `module "stack"` in `staging/main.tf`** (after `allowed_ip_ranges`):
+
+```hcl
+  cloudflare_zone_id     = data.terraform_remote_state.shared.outputs.cloudflare_zone_id
+  cloudflare_zone_name   = data.terraform_remote_state.shared.outputs.cloudflare_zone_name
+  custom_domains         = var.custom_domains
+  origin_certificate_pem = data.terraform_remote_state.shared.outputs.origin_certificate_pem
+  origin_private_key_pem = data.terraform_remote_state.shared.outputs.origin_private_key_pem
+```
+
+- [ ] **Step 3: Append to `production/variables.tf`**
+
+```hcl
+variable "custom_domains" {
+  type        = list(string)
+  description = "Public hostnames bound to the production app (behind the Cloudflare proxy)."
+  default     = ["czarnickwedding.com", "www.czarnickwedding.com"]
+}
+```
+
+- [ ] **Step 4: Edit `min_replicas` in `production/variables.tf`**
+
+```hcl
+variable "min_replicas" {
+  type        = number
+  description = "Minimum replicas. 1 keeps prod warm so guests never hit a cold start (~$3-14/mo); 0 = cheapest."
+  default     = 1
+}
+```
+
+- [ ] **Step 5: Add the same five module arguments to `production/main.tf`** as Step 2 (identical lines — the remote-state reference name is the same in both roots).
+
+- [ ] **Step 6: Verify** — fmt/validate as before. Expected: pass.
+
+### Task 6: Pipeline gets the Cloudflare secrets
+
+**Files:**
+- Modify: `.github/workflows/_terraform-env.yml` (env block, after `TF_VAR_allowed_ip_ranges`)
+
+- [ ] **Step 1: Append to the job `env:` block**
+
+```yaml
+      # Cloudflare provider auth — a single zone-scoped API token; required
+      # scopes documented in docs/deployment/README.md (Custom domains).
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+actionlint
+```
+
+Expected: no output (clean). If `actionlint` is not installed: `brew install actionlint` or `go run github.com/rhysd/actionlint/cmd/actionlint@latest`.
+
+### Task 7: Documentation
+
+**Files:**
+- Modify: `docs/deployment/README.md` — replace the whole "Custom domains, TLS, and Cloudflare" section
+- Modify: `AGENTS.md` — cost-guardrails paragraph
+
+- [ ] **Step 1: Replace the runbook section** "## Custom domains, TLS, and Cloudflare" (keeping the heading) with:
+
+```markdown
+## Custom domains, TLS, and Cloudflare
+
+Terraform manages all of it: Cloudflare DNS (proxied host records + `asuid.*`
+verification TXTs), zone SSL mode **Full (strict)**, a 15-year **Cloudflare
+Origin CA certificate** (issued in `shared`, uploaded and SNI-bound in each
+environment), and the Container App hostname bindings. The committed hostname
+sets live in each env root's `custom_domains` variable default.
+
+Two GitHub **secrets** feed the providers (also export them for local applies):
+
+- `CLOUDFLARE_API_TOKEN` — zone-scoped token: Zone:Read, DNS:Edit, Zone
+  Settings:Edit, and SSL and Certificates:Edit on the zone (the last is a
+  fallback auth path for Origin CA issuance).
+
+Notes:
+
+- The ACA **free managed cert is deliberately not used** — it silently fails to
+  renew behind the Cloudflare proxy. The Origin CA cert is trusted only by
+  Cloudflare, which is exactly the trust path in use.
+- The Origin CA **private key and both Cloudflare credentials live in Terraform
+  state** (AAD-locked storage account) — accepted trade-off, see the design doc.
+- Hostname ownership is validated via the `asuid.*` TXT records, so records can
+  stay **proxied (orange) the whole time**.
+- Cert rotation before 2041: taint `tls_private_key.origin` in `shared` and
+  re-apply shared → staging → production.
+
+### Origin lock + smoke hosts (after DNS is live)
+
+1. Set repo variable `ALLOWED_IP_RANGES_JSON` to the Cloudflare ranges (verify
+   at https://www.cloudflare.com/ips/) and re-run Infra. Only Cloudflare can
+   then reach the ACA default FQDNs:
+
+   ```
+   [{"name":"cf01","cidr":"173.245.48.0/20"},{"name":"cf02","cidr":"103.21.244.0/22"},
+    {"name":"cf03","cidr":"103.22.200.0/22"},{"name":"cf04","cidr":"103.31.4.0/22"},
+    {"name":"cf05","cidr":"141.101.64.0/18"},{"name":"cf06","cidr":"108.162.192.0/18"},
+    {"name":"cf07","cidr":"190.93.240.0/20"},{"name":"cf08","cidr":"188.114.96.0/20"},
+    {"name":"cf09","cidr":"197.234.240.0/22"},{"name":"cf10","cidr":"198.41.128.0/17"},
+    {"name":"cf11","cidr":"162.158.0.0/15"},{"name":"cf12","cidr":"104.16.0.0/13"},
+    {"name":"cf13","cidr":"104.24.0.0/14"},{"name":"cf14","cidr":"172.64.0.0/13"},
+    {"name":"cf15","cidr":"131.0.72.0/22"}]
+   ```
+
+   IPv4 ranges only, deliberately: the origin is reached via the IPv4
+   environment static IP, so Cloudflare's IPv6 egress ranges never apply here.
+
+2. Set repo variables `STAGING_SMOKE_HOST=staging.czarnickwedding.com` and
+   `PRODUCTION_SMOKE_HOST=czarnickwedding.com` so deploy smoke tests go through
+   Cloudflare. Set them as soon as the public hostnames serve — mandatory
+   before the origin lock, or the next deploy's smoke test hits the
+   now-blocked default FQDNs and fails.
+
+Optional hardening: Cloudflare **Authenticated Origin Pull** (mTLS) for a
+stronger origin lock than IP allow-listing alone.
+
+### One-time apex cutover (2026-07, for the record)
+
+The apex previously served from a home server via Cloudflare Tunnel. Cutover
+was: bind apex+www while the apex record still pointed at the tunnel (TXT
+validation), verify `www` end-to-end, then flip the apex record to the
+environment static IP (`terraform import` + apply, or an atomic dashboard edit
+when the plan would replace rather than update). A targeted apply
+(`-target=module.stack.azurerm_container_app_custom_domain.this ...`) was used
+once to stage bindings before DNS — do not reach for `-target` in normal
+operation.
+```
+
+- [ ] **Step 2: Also update the runbook architecture diagram note** — in the top diagram/description, nothing changes (already shows Cloudflare in front). Check the "Keeping prod warm (optional)" section: rewrite its first sentence to reflect that `min_replicas = 1` **is now the committed production default**, keeping the instructions for reverting to 0:
+
+```markdown
+## Keeping prod warm
+
+Production's committed default is `min_replicas = 1` (~$3–14/mo) so guests
+never hit a scale-from-zero cold start (~20–30 s). To go back to the cheapest
+setup, change the committed default back to `0` in
+`infra/terraform/environments/production/variables.tf` and let the Infra
+pipeline apply it. Don't use a local `terraform.tfvars` — the pipeline only
+passes the repo-variable-backed vars, so a tfvars override would be reverted on
+the next apply.
+```
+
+- [ ] **Step 3: Update `AGENTS.md`** cost guardrails line. Replace:
+
+`Spend is bounded structurally, not by a spending limit: scale-to-zero (min_replicas=0), capped max_replicas (staging 1, production 2), ...`
+
+with:
+
+`Spend is bounded structurally, not by a spending limit: staging scales to zero (min_replicas=0), production keeps one warm replica (min_replicas=1, deliberate — no guest-facing cold starts), capped max_replicas (staging 1, production 2), ...`
+
+(keep the rest of the sentence unchanged).
+
+- [ ] **Step 4: Verify** — `npm run lint` not needed (no app code); re-run the full Terraform gate + `actionlint` once more to close Part A:
+
+```bash
+terraform fmt -check -recursive infra/terraform && echo FMT-OK
+for env in shared staging production; do
+  terraform -chdir=infra/terraform/environments/$env validate
+done
+actionlint && echo LINT-OK
+```
+
+Expected: FMT-OK, 3× valid, LINT-OK.
+
+---
+
+## Part B — Live execution (Tasks 8–14; sequential, each gated on the previous)
+
+> Run from the worktree. Every apply reviews the plan output first. The live
+> site must keep serving from the old origin until Task 11 completes.
+
+### Task 8: Credentials and local environment
+
+Shell state does not persist between agent Bash calls — everything lands in an
+env file, sourced by every subsequent command. `ENVFILE` below means
+`<scratchpad>/issue23.env` (session scratchpad dir); `WT` means the worktree
+absolute path (see Global Constraints).
+
+- [ ] **Step 1 (USER):** In the Cloudflare dashboard create ONE API token, zone-scoped to `czarnickwedding.com`: **Zone:Read, DNS:Edit, Zone Settings:Edit, SSL and Certificates:Edit** (the last covers Origin CA issuance — do NOT create/configure an Origin CA key: the provider forbids dual credentials, and Origin CA keys are deprecated, removed 2026-09-30).
+
+- [ ] **Step 2 (USER pastes value interactively):** Store as a GitHub secret AND into the env file without the value touching command args or history. User runs (via `!` prompt or their own terminal):
+
+```bash
+gh secret set CLOUDFLARE_API_TOKEN --repo aczarnick/wedding-website        # paste when prompted
+```
+
+Then the user writes the value into the env file via a prompt-driven step (e.g. `read -rs` in their own shell, or pasting into the file with an editor). Agent must never echo the value.
+
+- [ ] **Step 3: Build the env file** (agent appends the non-secret entries; file already holds `export CLOUDFLARE_API_TOKEN=...` from Step 2):
+
+```bash
+umask 077
+cat >> "$ENVFILE" <<'EOF'
+export ARM_SUBSCRIPTION_ID=39aaecb8-c5d9-4cd4-9dab-125353808a9b
+export TF_VAR_budget_start_date=2026-08-01T00:00:00Z
+export TF_VAR_tfstate_storage_account_name=czwtfstate17540
+export TF_VAR_acr_name=czwacr11821
+EOF
+ALERT_EMAILS=$(az consumption budget show --budget-name budget-czw-shared \
+  --scope "/subscriptions/39aaecb8-c5d9-4cd4-9dab-125353808a9b/resourceGroups/rg-czw-shared" \
+  --query "notifications.*.contactEmails | [0]" -o json | jq -c .)
+printf 'export TF_VAR_alert_emails=%q\n' "$ALERT_EMAILS" >> "$ENVFILE"
+chmod 600 "$ENVFILE"
+```
+
+- [ ] **Step 4: Verify the env file** (without printing secrets):
+
+```bash
+source "$ENVFILE" && echo "token:${#CLOUDFLARE_API_TOKEN} emails:$TF_VAR_alert_emails"
+```
+
+Expected: non-zero token length, one-element JSON array for emails.
+
+### Task 9: Apply `shared`
+
+- [ ] **Step 1: Change freeze on** — disable the Infra workflow (re-enabled in Task 14) and confirm no Deploy is in flight:
+
+```bash
+gh workflow disable infra.yml --repo aczarnick/wedding-website
+gh run list --repo aczarnick/wedding-website --workflow deploy.yml -L1 --json status
+```
+
+- [ ] **Step 2: SSL-strict pre-flight** — `ssl=strict` is **zone-wide**; every proxied record must be either tunnel-backed (`*.cfargotunnel.com` CNAME — tunnels bypass origin-TLS mode) or one of the three in-scope hosts:
+
+```bash
+source "$ENVFILE" && ZONE_ID=$(curl -fsS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones?name=czarnickwedding.com" | jq -r '.result[0].id') \
+  && curl -fsS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+  "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records?proxied=true&per_page=100" \
+  | jq -r '.result[] | [.name,.type,.content] | @tsv'
+```
+
+Any proxied record pointing at a raw non-TLS/self-signed origin (not a tunnel) = STOP, resolve with the user before applying strict.
+
+- [ ] **Step 3: Plan:**
+
+```bash
+source "$ENVFILE" && terraform -chdir="$WT/infra/terraform/environments/shared" init -input=false -backend-config="storage_account_name=czwtfstate17540" \
+  && terraform -chdir="$WT/infra/terraform/environments/shared" plan -input=false -out=tfplan
+```
+
+Expected plan: **create** `cloudflare_zone_setting.ssl`, `tls_private_key.origin`, `tls_cert_request.origin`, `cloudflare_origin_ca_certificate.origin`; **no changes** to any existing azurerm resource. Any unexpected diff = stop and investigate (local vars mismatch).
+
+- [ ] **Step 4:** `source "$ENVFILE" && terraform -chdir="$WT/infra/terraform/environments/shared" apply -input=false tfplan`
+
+If `cloudflare_origin_ca_certificate` alone fails 401/403: the token lacks (or mis-scopes) SSL and Certificates:Edit — re-mint the token; nothing else in shared depends on it, so stop-and-fix is safe.
+
+- [ ] **Step 5: Verify** — `terraform -chdir=... output cloudflare_zone_id` non-empty; `terraform -chdir=... output -raw origin_certificate_pem | openssl x509 -noout -subject -enddate` shows CN `czarnickwedding.com`, expiry ~2041. Confirm zone SSL mode is now Full (strict) and the live site (old origin) still loads: `curl -fsS https://czarnickwedding.com/ >/dev/null && echo SITE-OK`.
+
+### Task 10: Apply `staging`, verify the full chain on a safe host
+
+- [ ] **Step 1:**
+
+```bash
+source "$ENVFILE" && terraform -chdir="$WT/infra/terraform/environments/staging" init -input=false -backend-config="storage_account_name=czwtfstate17540" \
+  && terraform -chdir="$WT/infra/terraform/environments/staging" plan -input=false -out=tfplan
+```
+
+Expected creates: `module.stack.cloudflare_dns_record.verification["staging.czarnickwedding.com"]`, `...cloudflare_dns_record.host["staging.czarnickwedding.com"]` (CNAME, proxied), `...azurerm_container_app_environment_certificate.origin[0]`, `...azurerm_container_app_custom_domain.this["staging.czarnickwedding.com"]`. Nothing else.
+
+- [ ] **Step 2:** `source "$ENVFILE" && terraform -chdir="$WT/infra/terraform/environments/staging" apply -input=false tfplan`
+
+If the custom-domain bind fails on TXT validation timing, re-run the apply once (Cloudflare is authoritative; propagation is seconds). If TXT content quoting perma-diffs appear, apply the quoting fix from Task 4 and re-validate.
+
+- [ ] **Step 3: Verify through Cloudflare (allow cold start):**
+
+```bash
+for i in $(seq 1 10); do curl -fsS --max-time 30 https://staging.czarnickwedding.com/ | grep -qF "October 10, 2026" && { echo STAGING-OK; break; }; sleep 6; done
+curl -sSI https://staging.czarnickwedding.com/ | grep -i '^server: cloudflare' && echo PROXIED-OK
+```
+
+Expected: STAGING-OK and PROXIED-OK.
+
+### Task 11: Production — staged bindings, then the apex cutover
+
+- [ ] **Step 1: Targeted apply — everything except the apex host record** (one-time exception; the apex record would conflict with the live tunnel record):
+
+```bash
+source "$ENVFILE" && terraform -chdir="$WT/infra/terraform/environments/production" init -input=false -backend-config="storage_account_name=czwtfstate17540" \
+  && terraform -chdir="$WT/infra/terraform/environments/production" plan -input=false -out=tfplan \
+  -target='module.stack.azurerm_container_app_custom_domain.this' \
+  -target='module.stack.cloudflare_dns_record.host["www.czarnickwedding.com"]'
+```
+
+Review: creates TXTs (apex + www), env cert, both bindings, the **www** host record, and updates the Container App (`min_replicas` 0→1). It must NOT touch any record named exactly `czarnickwedding.com`. Then:
+
+```bash
+source "$ENVFILE" && terraform -chdir="$WT/infra/terraform/environments/production" apply -input=false tfplan
+```
+
+If the two bindings (apex + www) 409-conflict against each other (concurrent PATCH of one app's ingress), re-run the apply or repeat it with `-parallelism=1` — don't investigate further.
+
+If the **apex binding** is rejected by ARM despite the TXT record (validation policy on A-record hosts), stop — the live site is unaffected; fall back to binding apex right after the DNS flip in Step 4 (accepting seconds of 404) and note it.
+
+- [ ] **Step 2: Verify www end-to-end** (proves cert + binding + proxy for the exact app the apex will move to):
+
+```bash
+for i in $(seq 1 10); do curl -fsS --max-time 30 https://www.czarnickwedding.com/ | grep -qF "October 10, 2026" && { echo WWW-OK; break; }; sleep 6; done
+```
+
+Also fingerprint-match www against the prod default FQDN (same `/_next/static/` asset set = same build).
+
+- [ ] **Step 3: Import the live apex record**:
+
+```bash
+source "$ENVFILE" \
+  && ZONE_ID=$(terraform -chdir="$WT/infra/terraform/environments/shared" output -raw cloudflare_zone_id) \
+  && RECORD_ID=$(curl -fsS -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+    "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/dns_records?name=czarnickwedding.com" \
+    | jq -re '[.result[] | select(.type=="CNAME" or .type=="A") | .id]
+              | if length == 1 then .[0] else error("expected exactly 1 apex host record, got \(length)") end') \
+  && terraform -chdir="$WT/infra/terraform/environments/production" import \
+       'module.stack.cloudflare_dns_record.host["czarnickwedding.com"]' "$ZONE_ID/$RECORD_ID"
+```
+
+The `length == 1` assertion is deliberate: apex names often carry MX/CAA records too, and a multi-line ID would garble the import mid-cutover.
+
+- [ ] **Step 4: Plan the flip and choose the path:**
+
+```bash
+source "$ENVFILE" && terraform -chdir="$WT/infra/terraform/environments/production" plan -input=false -out=tfplan
+```
+
+- Plan says `~ update in-place` for the apex record (type CNAME→A, content → `172.169.206.47`) → `terraform apply -input=false tfplan` (atomic PATCH).
+- Plan says `-/+ destroy and then create replacement` → **do not apply**. USER flips the record in the Cloudflare dashboard instead (edit existing record → type `A`, value `172.169.206.47`, proxy ON — one atomic edit), then `terraform plan` again → expect no changes (or a trivial in-place metadata diff; apply that).
+
+- [ ] **Step 5: Verify the apex serves the ACA build:**
+
+```bash
+curl -fsS https://czarnickwedding.com/ | grep -qF "October 10, 2026" && echo APEX-OK
+# fingerprint: apex asset set must now match the prod default FQDN, not the old origin
+```
+
+Also confirm the `x-served-by: czarnickwedding.com` header (old origin) is gone. The home tunnel is now dark — decommissioning it is the user's follow-up, out of scope.
+
+### Task 12: Smoke hosts first, then the origin lock
+
+- [ ] **Step 1: Set the smoke-host repo variables BEFORE the lock** (both public hostnames already serve after Task 11; doing this first means no window where a deploy would smoke-test the soon-to-be-blocked default FQDNs):
+
+```bash
+gh variable set STAGING_SMOKE_HOST --repo aczarnick/wedding-website --body staging.czarnickwedding.com
+gh variable set PRODUCTION_SMOKE_HOST --repo aczarnick/wedding-website --body czarnickwedding.com
+```
+
+- [ ] **Step 2: Set the origin-lock repo variable and env file entry** (exact JSON below, after eyeballing https://www.cloudflare.com/ips/ for changes; IPv4-only is deliberate — the origin is reached via the IPv4 static IP):
+
+```bash
+CF_RANGES='[{"name":"cf01","cidr":"173.245.48.0/20"},{"name":"cf02","cidr":"103.21.244.0/22"},{"name":"cf03","cidr":"103.22.200.0/22"},{"name":"cf04","cidr":"103.31.4.0/22"},{"name":"cf05","cidr":"141.101.64.0/18"},{"name":"cf06","cidr":"108.162.192.0/18"},{"name":"cf07","cidr":"190.93.240.0/20"},{"name":"cf08","cidr":"188.114.96.0/20"},{"name":"cf09","cidr":"197.234.240.0/22"},{"name":"cf10","cidr":"198.41.128.0/17"},{"name":"cf11","cidr":"162.158.0.0/15"},{"name":"cf12","cidr":"104.16.0.0/13"},{"name":"cf13","cidr":"104.24.0.0/14"},{"name":"cf14","cidr":"172.64.0.0/13"},{"name":"cf15","cidr":"131.0.72.0/22"}]'
+gh variable set ALLOWED_IP_RANGES_JSON --repo aczarnick/wedding-website --body "$CF_RANGES"
+printf 'export TF_VAR_allowed_ip_ranges=%q\n' "$CF_RANGES" >> "$ENVFILE"
+```
+
+- [ ] **Step 3: Re-apply staging and production** (plan first; expected change: ingress `ip_security_restriction` blocks added on each app, nothing else):
+
+```bash
+source "$ENVFILE" && for env in staging production; do
+  terraform -chdir="$WT/infra/terraform/environments/$env" plan -input=false -out=tfplan \
+    && terraform -chdir="$WT/infra/terraform/environments/$env" apply -input=false tfplan
+done
+```
+
+- [ ] **Step 4: Verify the lock:**
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' --max-time 30 https://ca-czw-production.whiteriver-ca9e24a5.centralus.azurecontainerapps.io/   # expect 403 (or connection reset), NOT 200
+curl -fsS https://czarnickwedding.com/ | grep -qF "October 10, 2026" && echo STILL-UP
+curl -fsS https://staging.czarnickwedding.com/ >/dev/null && echo STAGING-STILL-UP
+```
+
+### Task 13: End-to-end pipeline proof
+
+- [ ] **Step 1: Dispatch Deploy** (rebuilds master HEAD — same site — and exercises both smoke tests through Cloudflare; **the production job pauses for the USER's approval** in the GitHub `production` environment):
+
+```bash
+gh workflow run deploy.yml --repo aczarnick/wedding-website
+RUN_ID=$(gh run list --repo aczarnick/wedding-website --workflow deploy.yml -L1 --json databaseId -q '.[0].databaseId')
+gh run watch "$RUN_ID" --repo aczarnick/wedding-website
+```
+
+Expected: staging + production deploy jobs green with smoke tests hitting the public hostnames.
+
+### Task 14: Final consistency checks and freeze-off
+
+- [ ] **Step 1: No-op plans everywhere** (proves code == live state):
+
+```bash
+source "$ENVFILE" && for env in shared staging production; do
+  terraform -chdir="$WT/infra/terraform/environments/$env" plan -input=false -detailed-exitcode
+  echo "$env exit: $?"   # expect 0 (no changes) for all three
+done
+```
+
+If production exits 2 with a perma-diff on `azurerm_container_app` ingress (bound domains surfacing on the computed block), the fix is extending that resource's `lifecycle ignore_changes` — known azurerm quirk, don't debug from scratch.
+
+- [ ] **Step 2: `min_replicas=1` live:** `az containerapp show -g rg-czw-production -n ca-czw-production --query properties.template.scale.minReplicas` → `1`.
+
+- [ ] **Step 3: Re-enable the Infra workflow** (freeze off):
+
+```bash
+gh workflow enable infra.yml --repo aczarnick/wedding-website
+```
+
+- [ ] **Step 4: Re-run the repo verification gate** (fmt, validate ×3, actionlint) one last time; then hand over to code review (separate workflow step — no commits).
+
+- [ ] **Step 5: Handoff notes for the USER** (include in the final report):
+  - PR the worktree branch promptly; until merge, live infra intentionally runs ahead of `master`.
+  - The post-merge Infra run pauses **twice** for approvals (`infra` env for shared, `production` env) and should apply as a **no-op** — that no-op is the reconciliation proof.
+  - Comment on issue #23 that the open question was resolved: full Terraform automation via the Cloudflare provider, token/key/private key in AAD-locked state accepted; then close it.
+  - Decommission the home tunnel whenever convenient (nothing routes to it after the cutover).
+  - Delete the scratchpad env file (`rm -P "$ENVFILE"`).
+
+## Rollback notes
+
+- Before Task 11 Step 4, nothing guest-facing changed: abort freely; optionally `terraform destroy -target` the new bindings/records or leave them (harmless).
+- After the apex flip, rollback = point the apex record back at the tunnel (dashboard edit), which restores the old origin in seconds; then `terraform state rm 'module.stack.cloudflare_dns_record.host["czarnickwedding.com"]'` to stop Terraform from re-flipping — **and** drop the apex from `production/variables.tf`'s `custom_domains` default (or hold all applies), otherwise the next apply tries to create an A record over the live tunnel CNAME.
+- Origin lock rollback = unset `ALLOWED_IP_RANGES_JSON`/`TF_VAR_allowed_ip_ranges` and re-apply (ingress open again).

--- a/docs/superpowers/specs/2026-07-10-cloudflare-custom-domain-tls-design.md
+++ b/docs/superpowers/specs/2026-07-10-cloudflare-custom-domain-tls-design.md
@@ -1,0 +1,185 @@
+# Cloudflare custom domains + TLS for Azure Container Apps (issue #23)
+
+**Date:** 2026-07-10
+**Issue:** https://github.com/aczarnick/wedding-website/issues/23
+**Status:** Approved design, pending implementation
+
+## Goal
+
+Serve the site on `czarnickwedding.com` (apex), `www.czarnickwedding.com`, and
+`staging.czarnickwedding.com` through the Cloudflare proxy (Full strict TLS),
+backed by the Azure Container Apps deployments, with the ACA origins locked to
+Cloudflare IPs and deploy smoke tests routed through the public hostnames.
+Everything reproducible in Terraform.
+
+## Current state (verified 2026-07-10)
+
+- Apex `czarnickwedding.com` is **live for guests**, proxied through Cloudflare
+  to a **home server via Cloudflare Tunnel** (serves a different build than ACA;
+  `x-served-by: czarnickwedding.com` header). Zero-downtime cutover required.
+- `www` and `staging` have **no DNS records** (dead).
+- No custom domains bound on either Container App; no `asuid.*` TXT records; no
+  certs uploaded.
+- Repo variables `ALLOWED_IP_RANGES_JSON`, `STAGING_SMOKE_HOST`,
+  `PRODUCTION_SMOKE_HOST` do not exist. The pipeline is already wired to consume
+  all three.
+- Both ACA apps healthy on default FQDNs (cold start ~20-30 s from zero).
+  Environments: `cae-czw-staging` (static IP 52.154.166.48),
+  `cae-czw-production` (static IP 172.169.206.47), both Central US.
+
+## Decisions (from design discussion)
+
+1. **Full Terraform automation** — Cloudflare DNS, Origin CA cert issuance, ACA
+   cert upload + hostname binding all in Terraform (Cloudflare provider v5).
+2. **`min_replicas = 1` for production** (committed default) — no guest-facing
+   cold starts (~$3–14/mo).
+3. **`www` is bound to the production app** (serves the site directly, no
+   redirect rule). It doubles as the pre-cutover verification host.
+4. **Layout: extend the existing roots** (`shared` → `staging` → `production`),
+   no new root module. Cert material flows from `shared` to the env roots via
+   the existing remote-state read.
+5. **Execution:** this session applies everything locally from the worktree and
+   drives the live cutover (user flips/authorizes the apex change). No commits
+   or PRs by the agent.
+
+## Architecture
+
+### Providers
+
+- All three roots gain `cloudflare = { source = "cloudflare/cloudflare",
+  version = "~> 5" }`; `shared` also gains `tls` (`hashicorp/tls`, `~> 4`).
+- `modules/env-stack` declares `cloudflare` in its own `required_providers`
+  (required for non-hashicorp providers used inside a module).
+- Provider auth is env-var driven, matching the existing azurerm pattern (no
+  credentials in HCL):
+  - `CLOUDFLARE_API_TOKEN` — a single zone-scoped token: Zone:Read, DNS:Edit,
+    Zone Settings:Edit, SSL and Certificates:Edit for `czarnickwedding.com`.
+    SSL and Certificates:Edit covers Origin CA issuance. No Origin CA key:
+    the provider forbids dual credentials and Origin CA keys are deprecated
+    (removed by Cloudflare 2026-09-30).
+
+### `shared` root (new resources)
+
+- `data "cloudflare_zone"` — filter by `var.cloudflare_zone_name`
+  (default `"czarnickwedding.com"`, committed).
+- `tls_private_key` (RSA 2048) → `tls_cert_request` (CN apex, SANs apex +
+  `*.czarnickwedding.com`) → `cloudflare_origin_ca_certificate`
+  (`request_type = "origin-rsa"`, `requested_validity = 5475` days / 15 years).
+  One cert serves both environments.
+- `cloudflare_zone_setting` `ssl = "strict"` (Full strict). Safe to apply before
+  cutover: the tunnel-served site does not use the origin-cert path.
+- New outputs consumed by env roots: `cloudflare_zone_id`,
+  `origin_certificate_pem`, `origin_private_key_pem` (sensitive).
+
+### `env-stack` module (new, optional inputs — off when unset)
+
+Inputs: `cloudflare_zone_id`, `custom_domains` (list of hostnames),
+`origin_certificate_pem`, `origin_private_key_pem` (sensitive), plus
+`cloudflare_zone_name` to detect the apex.
+
+Resources (per hostname unless noted):
+
+- `cloudflare_dns_record` **verification TXT**: name `asuid.<host>`, content =
+  the app's `custom_domain_verification_id`. TXT validation works with the
+  proxy on — the orange cloud never needs to come off.
+- `cloudflare_dns_record` **host record**, `proxied = true`, `ttl = 1` (auto):
+  - apex → `A` to the environment static IP
+  - others → `CNAME` to the app's default FQDN
+- `azurerm_container_app_environment_certificate` (one per env): the Origin CA
+  cert + key PEM concatenated, base64-encoded, empty password.
+- `azurerm_container_app_custom_domain` per hostname, SNI-bound to that cert,
+  `depends_on` the TXT records (ownership validation precedes binding).
+- `modules/container-app` gains an `id` output (needed by the binding resource).
+
+### Env roots
+
+- `staging`: `custom_domains = ["staging.czarnickwedding.com"]`.
+- `production`: `custom_domains = ["czarnickwedding.com",
+  "www.czarnickwedding.com"]`; `min_replicas` default `0` → `1`.
+
+### Workflow changes
+
+- `_terraform-env.yml`: pass the GitHub secret `CLOUDFLARE_API_TOKEN` as a job
+  env var (the provider reads it natively). No workflow logic changes.
+
+### Docs
+
+- Rewrite the runbook section "Custom domains, TLS, and Cloudflare" in
+  `docs/deployment/README.md`: credentials to mint, what Terraform now owns,
+  the cutover checklist, and the origin-lock / smoke-host repo variables.
+- `AGENTS.md` cost guardrails: production is now `min_replicas=1` (~$3–14/mo,
+  deliberate; staging stays scale-to-zero).
+
+## The apex cutover (zero downtime)
+
+The apex record currently carries live guest traffic to the tunnel. Two
+hazards: (a) Terraform cannot *create* the apex record while the tunnel record
+exists (name conflict), and (b) a CNAME→A type change may plan as
+delete-and-recreate (brief DNS gap). Sequencing:
+
+1. **Targeted first apply** (documented one-time exception to "no `-target`"):
+   apply production *excluding the apex host DNS record* — TXTs, cert, bindings
+   (apex + www validate via TXT while apex still points at the tunnel), www
+   host record.
+2. **Verify www end-to-end**: `https://www.czarnickwedding.com` through the
+   Cloudflare proxy serves the ACA build (asset-fingerprint check), valid cert.
+3. **Import the existing apex record** into state, then `terraform plan`:
+   - plan shows **update in-place** → apply (atomic API PATCH; Terraform flips
+     the record).
+   - plan shows **replacement** → do NOT apply; flip the record manually in the
+     Cloudflare dashboard (single atomic edit → `A 172.169.206.47`, proxied),
+     then `terraform plan` again → no-op.
+4. **Verify apex** serves the ACA build. Old tunnel origin is now dark (user
+   decommissions the tunnel at leisure — out of scope).
+
+If the apex *binding* (step 1) is rejected by ARM despite the TXT record, stop
+— the live site is unaffected — and reassess (fallback: bind apex immediately
+after the DNS flip, accepting seconds of 404).
+
+## Execution order (whole session)
+
+1. User mints the Cloudflare API token; store as a GitHub secret
+   (`gh secret set`), export locally for applies.
+2. Apply `shared` (cert issued, SSL strict) — no traffic impact. Local applies
+   pass exactly the pipeline's variables (`TF_VAR_alert_emails`,
+   `TF_VAR_budget_start_date`, etc.) to avoid state churn.
+3. Apply `staging`; verify `https://staging.czarnickwedding.com` (200 + smoke
+   string, ACA build).
+4. Production cutover per section above.
+5. Set repo vars `STAGING_SMOKE_HOST=staging.czarnickwedding.com`,
+   `PRODUCTION_SMOKE_HOST=czarnickwedding.com` **before** the origin lock (no
+   window where a deploy smoke-tests the soon-to-be-blocked default FQDNs).
+   Then **origin lock**: set repo var `ALLOWED_IP_RANGES_JSON` (Cloudflare
+   IPv4 ranges, verified against https://www.cloudflare.com/ips/), re-apply
+   staging + production with the same value locally. Verify: default FQDNs now
+   refused, public hostnames still 200.
+6. Dispatch the Deploy workflow to prove the smoke path through Cloudflare
+   end-to-end. A change freeze holds from the first apply until the PR merges
+   (Infra workflow disabled during execution, re-enabled at the end).
+7. User reviews the worktree diff (code-reviewed) and PRs it. Until merge, live
+   infra intentionally runs ahead of `master`; merging reconciles (the infra
+   pipeline apply should then be a no-op).
+
+## Security & trade-offs (accepted)
+
+- The cert **private key lives in Terraform state** (AAD-locked storage
+  account — same posture as existing alert-email handling). The provider
+  credentials (the API token) are env-vars only and are never
+  persisted to state. The 15-year Origin CA cert is trusted only by
+  Cloudflare, limiting blast radius.
+- ACA free managed certs deliberately avoided (silent renewal failure behind
+  the proxy — see runbook).
+- `-target` used exactly once, for the cutover, documented in the runbook.
+- Authenticated Origin Pull (mTLS) remains optional future hardening — out of
+  scope.
+
+## Verification / done criteria
+
+- `terraform fmt -check -recursive`, per-env `terraform validate`, and
+  `actionlint` pass (CI gate).
+- All three hostnames serve the ACA build through the Cloudflare proxy with
+  valid TLS (Full strict).
+- Direct requests to both default ACA FQDNs are blocked (origin locked).
+- A Deploy workflow run passes both smoke tests via the public hostnames.
+- `terraform plan` in all three env dirs is a no-op afterwards.
+- Issue #23's checklist fully satisfied; `min_replicas=1` live in production.

--- a/infra/terraform/environments/production/.terraform.lock.hcl
+++ b/infra/terraform/environments/production/.terraform.lock.hcl
@@ -1,10 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
+    "h1:hU72otEs26Wx6tcJD9igX6I/BQtVgeRuaIe3s/hn6bQ=",
+    "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
+    "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
+    "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",
+    "zh:42c27f3cd62979e70716c51f682a3d131d51ad76d86dff83d8cdbfffcebac841",
+    "zh:4c8cd464f9b6ecde5cd4430bbba4be3b810826105e51ef6328b6a2b69f821443",
+    "zh:586ea42ef74d6c5bc4c9b89da6b1f8618a19f4e80272fe8d615e7d5b11c491af",
+    "zh:b09b86c7cac7085e01c9b7a828f09d13c44589d3e3cd42f0b694ca3e4cd3ed0a",
+    "zh:eac80665e60c701b37a6318f4e405d67f1720f8da5f93135c6256049282d3367",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.80.0"
   constraints = "~> 4.0"
   hashes = [
+    "h1:IGLCHEb0I3CGzLdrzzD7E3aUDrUDQt3dT6FYL1qQtSQ=",
     "h1:R8n0T2WWUxa65nw64W/Q+M2X9My84/lebmKwAzixlu8=",
     "zh:1287b44676ced8f2d8131b1746a027f05edba2e5aa7e3ecdbaa6887aaad68431",
     "zh:1ae7263cafd4f9ffff6a595190ee940af929bda026bddd7db2cd733596878597",

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -20,6 +20,11 @@ module "stack" {
   min_replicas               = var.min_replicas
   max_replicas               = var.max_replicas
   allowed_ip_ranges          = var.allowed_ip_ranges
+  cloudflare_zone_id         = data.terraform_remote_state.shared.outputs.cloudflare_zone_id
+  cloudflare_zone_name       = data.terraform_remote_state.shared.outputs.cloudflare_zone_name
+  custom_domains             = var.custom_domains
+  origin_certificate_pem     = data.terraform_remote_state.shared.outputs.origin_certificate_pem
+  origin_private_key_pem     = data.terraform_remote_state.shared.outputs.origin_private_key_pem
   alert_emails               = var.alert_emails
   monthly_budget_amount      = var.monthly_budget_amount
   budget_start_date          = var.budget_start_date

--- a/infra/terraform/environments/production/outputs.tf
+++ b/infra/terraform/environments/production/outputs.tf
@@ -8,15 +8,3 @@ output "default_fqdn" {
   description = "Default ingress FQDN (smoke-test target). Retrieve with: terraform output -raw default_fqdn"
   sensitive   = true # the Cloudflare-hidden origin — keep out of public apply logs
 }
-
-output "custom_domain_verification_id" {
-  value       = module.stack.custom_domain_verification_id
-  description = "Value for the asuid.<host> TXT record. Retrieve with: terraform output -raw custom_domain_verification_id"
-  sensitive   = true # azurerm marks this attribute sensitive; root output must match
-}
-
-output "environment_static_ip" {
-  value       = module.stack.environment_static_ip
-  description = "Environment static IP (apex A-record target). Retrieve with: terraform output -raw environment_static_ip"
-  sensitive   = true # origin IP — keep out of public apply logs
-}

--- a/infra/terraform/environments/production/terraform.tfvars.example
+++ b/infra/terraform/environments/production/terraform.tfvars.example
@@ -2,7 +2,8 @@
 tfstate_storage_account_name = "czwtfstate0001"
 alert_emails                 = ["aczarnick@example.com"]
 budget_start_date            = "2026-08-01T00:00:00Z"
-# Warm prod (no cold starts): change the committed default min_replicas = 1 in
-# variables.tf so the pipeline applies it — a local tfvars override is reverted.
+# Prod runs warm by default (min_replicas = 1, no cold starts). To go back to
+# scale-to-zero savings, change the committed default to 0 in variables.tf so
+# the pipeline applies it — a local tfvars override is reverted.
 # Origin lock (allowed_ip_ranges) is set via the ALLOWED_IP_RANGES_JSON GitHub
 # repo variable, NOT here. See docs/deployment/README.md.

--- a/infra/terraform/environments/production/variables.tf
+++ b/infra/terraform/environments/production/variables.tf
@@ -11,8 +11,8 @@ variable "resource_group_name" {
 
 variable "min_replicas" {
   type        = number
-  description = "Minimum replicas. 0 = cheapest (guests may hit a cold start); set default to 1 here to keep prod warm (~$3-14/mo)."
-  default     = 0
+  description = "Minimum replicas. 1 keeps prod warm so guests never hit a cold start (~$3-14/mo); 0 = cheapest."
+  default     = 1
 }
 
 variable "max_replicas" {
@@ -55,4 +55,10 @@ variable "tags" {
     environment = "production"
     managed     = "terraform"
   }
+}
+
+variable "custom_domains" {
+  type        = list(string)
+  description = "Public hostnames bound to the production app (behind the Cloudflare proxy)."
+  default     = ["czarnickwedding.com", "www.czarnickwedding.com"]
 }

--- a/infra/terraform/environments/production/versions.tf
+++ b/infra/terraform/environments/production/versions.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
   }
 }
 

--- a/infra/terraform/environments/shared/.terraform.lock.hcl
+++ b/infra/terraform/environments/shared/.terraform.lock.hcl
@@ -1,10 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
+    "h1:hU72otEs26Wx6tcJD9igX6I/BQtVgeRuaIe3s/hn6bQ=",
+    "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
+    "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
+    "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",
+    "zh:42c27f3cd62979e70716c51f682a3d131d51ad76d86dff83d8cdbfffcebac841",
+    "zh:4c8cd464f9b6ecde5cd4430bbba4be3b810826105e51ef6328b6a2b69f821443",
+    "zh:586ea42ef74d6c5bc4c9b89da6b1f8618a19f4e80272fe8d615e7d5b11c491af",
+    "zh:b09b86c7cac7085e01c9b7a828f09d13c44589d3e3cd42f0b694ca3e4cd3ed0a",
+    "zh:eac80665e60c701b37a6318f4e405d67f1720f8da5f93135c6256049282d3367",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.80.0"
   constraints = "~> 4.0"
   hashes = [
+    "h1:IGLCHEb0I3CGzLdrzzD7E3aUDrUDQt3dT6FYL1qQtSQ=",
     "h1:R8n0T2WWUxa65nw64W/Q+M2X9My84/lebmKwAzixlu8=",
     "zh:1287b44676ced8f2d8131b1746a027f05edba2e5aa7e3ecdbaa6887aaad68431",
     "zh:1ae7263cafd4f9ffff6a595190ee940af929bda026bddd7db2cd733596878597",
@@ -18,5 +37,27 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:99585400adafdc8aedd37cb1e715e986ce39612ba18bab34fd8749aae37593d7",
     "zh:a1d4ccf5e1afb4e440119b3ff2e41c3192979ea9b1735cc9d91a7fb8684339e0",
     "zh:ea3be732d424c36634dd105425879ea7610224cada0c59ed6172ce67b610289d",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/tls" {
+  version     = "4.3.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:5bCU/c+2HUh7GhclzNSH6gAuoCS4inW3obEtRAwu6WQ=",
+    "h1:j/BqLS2N2AScZyotd9nZpHdieJ7e5S8y+A+ZfIu8kL8=",
+    "zh:0ab58d6f8991d436c7d2dbd89ed814709b949b07ac5a54ee53b0aec1fa772a8b",
+    "zh:60b347abcb56f45d97c56f14d895069cd15a83993f199777f571b79fea3642ee",
+    "zh:6889be32640349230de3f23856e6f04e0e9ced4a84a27d3f552fa54684448218",
+    "zh:73f8e1ecf7135033165fb14b7e8bf4d656f3ce13065ec35762ea0481975328c7",
+    "zh:94ce25ee253eca0b42cae9c856b36bca8103b6453012d1b279c3623c805f2d42",
+    "zh:96bc6de9fd67bc446fd11257872e1ffb1029a996ed1d65a3f6b43f6d408ad9ab",
+    "zh:97c609a310a51bfd504d704e036d72064a84bf0bdb36cc08cd4cc66098212b41",
+    "zh:a12c16e94533c5bd123f75032576b9dc91dd5d5ccd5f7cf331d0f2e1adc55cf8",
+    "zh:c4f014f876adf7af57188795050bda5b0029d8c7d7773031102b6c36dcf1fc21",
+    "zh:d9b0a21583aaa3df3a95394fb949a3c515ff71c2ff5a1fc4a73d364aa90bfca5",
+    "zh:da510d22f0c6d71ad19a76406f106b782448f512375787ecfabb338ed1e311a7",
+    "zh:f0e9447a9ce3a24cdaa113089e65663c836d8b9bfdb915a1c0284e0112cab5c0",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
   ]
 }

--- a/infra/terraform/environments/shared/cloudflare.tf
+++ b/infra/terraform/environments/shared/cloudflare.tf
@@ -1,0 +1,57 @@
+data "cloudflare_zone" "site" {
+  filter = {
+    name = var.cloudflare_zone_name
+  }
+}
+
+# Cloudflare-to-origin TLS mode. "strict" requires the origin to present a
+# cert Cloudflare trusts — the Origin CA certificate below. Zone-wide setting:
+# tunnel-backed records bypass this path, but any other proxied record must
+# serve valid TLS.
+resource "cloudflare_zone_setting" "ssl" {
+  zone_id    = data.cloudflare_zone.site.id
+  setting_id = "ssl"
+  value      = "strict"
+}
+
+# One Origin CA certificate (apex + wildcard) shared by both environments.
+# Trusted only by the Cloudflare edge, never by browsers — deliberately not
+# the ACA managed cert (see docs/deployment/README.md). The private key lives
+# in Terraform state; the state account is AAD-locked.
+resource "tls_private_key" "origin" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "tls_cert_request" "origin" {
+  private_key_pem = tls_private_key.origin.private_key_pem
+  dns_names       = [var.cloudflare_zone_name, "*.${var.cloudflare_zone_name}"]
+
+  subject {
+    common_name = var.cloudflare_zone_name
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# create_before_destroy across the chain: the provider's delete REVOKES the
+# certificate, and the environments keep serving their uploaded copies until
+# their own (approval-gated) applies run — issue the replacement first.
+resource "cloudflare_origin_ca_certificate" "origin" {
+  csr = tls_cert_request.origin.cert_request_pem
+  # Wildcard first: the API returns hostnames sorted, and a mismatch on this
+  # ForceNew list would replace (revoke!) the cert on every apply.
+  hostnames          = ["*.${var.cloudflare_zone_name}", var.cloudflare_zone_name]
+  request_type       = "origin-rsa"
+  requested_validity = 5475 # 15 years — rotation is a manual re-apply, documented in the runbook
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/infra/terraform/environments/shared/outputs.tf
+++ b/infra/terraform/environments/shared/outputs.tf
@@ -22,3 +22,24 @@ output "log_analytics_workspace_id" {
   value       = azurerm_log_analytics_workspace.shared.id
   description = "Shared Log Analytics workspace ID, consumed by the env stacks."
 }
+
+output "cloudflare_zone_id" {
+  value       = data.cloudflare_zone.site.id
+  description = "Cloudflare zone ID, consumed by the env stacks for DNS records."
+}
+
+output "cloudflare_zone_name" {
+  value       = var.cloudflare_zone_name
+  description = "Zone apex name — env stacks use it to pick A vs CNAME per hostname."
+}
+
+output "origin_certificate_pem" {
+  value       = cloudflare_origin_ca_certificate.origin.certificate
+  description = "Origin CA certificate (PEM), uploaded to each Container App Environment."
+}
+
+output "origin_private_key_pem" {
+  value       = tls_private_key.origin.private_key_pem
+  description = "Origin CA private key (PEM). Sensitive — lives only in state."
+  sensitive   = true
+}

--- a/infra/terraform/environments/shared/variables.tf
+++ b/infra/terraform/environments/shared/variables.tf
@@ -44,6 +44,12 @@ variable "budget_start_date" {
   description = "Budget start, first day of a month in RFC3339 UTC, e.g. 2026-08-01T00:00:00Z."
 }
 
+variable "cloudflare_zone_name" {
+  type        = string
+  description = "Cloudflare zone (the site's domain). Zone ID is looked up at plan time."
+  default     = "czarnickwedding.com"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Common tags."

--- a/infra/terraform/environments/shared/versions.tf
+++ b/infra/terraform/environments/shared/versions.tf
@@ -5,6 +5,14 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
   }
 }
 
@@ -19,3 +27,8 @@ provider "azurerm" {
   # stop azurerm v4 from auto-registering all of them (which 403s and fails plan).
   resource_provider_registrations = "none"
 }
+
+# Auth via the CLOUDFLARE_API_TOKEN env var — a GitHub secret in CI, exported
+# locally; required scopes in docs/deployment/README.md. Never hardcode
+# credentials here.
+provider "cloudflare" {}

--- a/infra/terraform/environments/staging/.terraform.lock.hcl
+++ b/infra/terraform/environments/staging/.terraform.lock.hcl
@@ -1,10 +1,29 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.21.1"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:gNF1Sro3G9nXhtdkitXwDVKxI1jpBAf8KPv+Y4kAJwk=",
+    "h1:hU72otEs26Wx6tcJD9igX6I/BQtVgeRuaIe3s/hn6bQ=",
+    "zh:049719425b8be43d9d4f0c208217aca0baa22374f061d7ff92f02563490f649c",
+    "zh:0a8a3c1b26680b437fe9e7910ca81e532d36f8efacfb14f45690b6a779856993",
+    "zh:32b61f80892243f7ab8e453fa038c1f3e2aac733ccb98307c2cfe798b2793b32",
+    "zh:42c27f3cd62979e70716c51f682a3d131d51ad76d86dff83d8cdbfffcebac841",
+    "zh:4c8cd464f9b6ecde5cd4430bbba4be3b810826105e51ef6328b6a2b69f821443",
+    "zh:586ea42ef74d6c5bc4c9b89da6b1f8618a19f4e80272fe8d615e7d5b11c491af",
+    "zh:b09b86c7cac7085e01c9b7a828f09d13c44589d3e3cd42f0b694ca3e4cd3ed0a",
+    "zh:eac80665e60c701b37a6318f4e405d67f1720f8da5f93135c6256049282d3367",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "4.80.0"
   constraints = "~> 4.0"
   hashes = [
+    "h1:IGLCHEb0I3CGzLdrzzD7E3aUDrUDQt3dT6FYL1qQtSQ=",
     "h1:R8n0T2WWUxa65nw64W/Q+M2X9My84/lebmKwAzixlu8=",
     "zh:1287b44676ced8f2d8131b1746a027f05edba2e5aa7e3ecdbaa6887aaad68431",
     "zh:1ae7263cafd4f9ffff6a595190ee940af929bda026bddd7db2cd733596878597",

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -20,6 +20,11 @@ module "stack" {
   min_replicas               = var.min_replicas
   max_replicas               = var.max_replicas
   allowed_ip_ranges          = var.allowed_ip_ranges
+  cloudflare_zone_id         = data.terraform_remote_state.shared.outputs.cloudflare_zone_id
+  cloudflare_zone_name       = data.terraform_remote_state.shared.outputs.cloudflare_zone_name
+  custom_domains             = var.custom_domains
+  origin_certificate_pem     = data.terraform_remote_state.shared.outputs.origin_certificate_pem
+  origin_private_key_pem     = data.terraform_remote_state.shared.outputs.origin_private_key_pem
   alert_emails               = var.alert_emails
   monthly_budget_amount      = var.monthly_budget_amount
   budget_start_date          = var.budget_start_date

--- a/infra/terraform/environments/staging/outputs.tf
+++ b/infra/terraform/environments/staging/outputs.tf
@@ -8,15 +8,3 @@ output "default_fqdn" {
   description = "Default ingress FQDN (smoke-test target). Retrieve with: terraform output -raw default_fqdn"
   sensitive   = true # the Cloudflare-hidden origin — keep out of public apply logs
 }
-
-output "custom_domain_verification_id" {
-  value       = module.stack.custom_domain_verification_id
-  description = "Value for the asuid.<host> TXT record. Retrieve with: terraform output -raw custom_domain_verification_id"
-  sensitive   = true # azurerm marks this attribute sensitive; root output must match
-}
-
-output "environment_static_ip" {
-  value       = module.stack.environment_static_ip
-  description = "Environment static IP (apex A-record target). Retrieve with: terraform output -raw environment_static_ip"
-  sensitive   = true # origin IP — keep out of public apply logs
-}

--- a/infra/terraform/environments/staging/variables.tf
+++ b/infra/terraform/environments/staging/variables.tf
@@ -56,3 +56,9 @@ variable "tags" {
     managed     = "terraform"
   }
 }
+
+variable "custom_domains" {
+  type        = list(string)
+  description = "Public hostnames bound to the staging app (behind the Cloudflare proxy)."
+  default     = ["staging.czarnickwedding.com"]
+}

--- a/infra/terraform/environments/staging/versions.tf
+++ b/infra/terraform/environments/staging/versions.tf
@@ -5,6 +5,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
   }
 }
 

--- a/infra/terraform/modules/container-app/outputs.tf
+++ b/infra/terraform/modules/container-app/outputs.tf
@@ -17,3 +17,8 @@ output "latest_revision_name" {
   value       = azurerm_container_app.this.latest_revision_name
   description = "Latest revision name."
 }
+
+output "id" {
+  value       = azurerm_container_app.this.id
+  description = "Container App resource ID (custom-domain bindings attach to it)."
+}

--- a/infra/terraform/modules/env-stack/custom-domains.tf
+++ b/infra/terraform/modules/env-stack/custom-domains.tf
@@ -1,0 +1,64 @@
+# Hostname-ownership TXT records. ACA validates via asuid.<host>, which keeps
+# working while the host record stays proxied (orange cloud) — that is what
+# makes a zero-downtime cutover possible.
+resource "cloudflare_dns_record" "verification" {
+  for_each = var.custom_domains
+
+  zone_id = var.cloudflare_zone_id
+  name    = "asuid.${each.value}"
+  type    = "TXT"
+  # Quoted: the Cloudflare API canonicalizes TXT content to its quoted form;
+  # sending it unquoted risks a perpetual plan diff on some v5 releases.
+  content = "\"${module.app.custom_domain_verification_id}\""
+  ttl     = 1
+}
+
+# Cloudflare Origin CA cert for the environment — deliberately not the ACA
+# managed cert (see docs/deployment/README.md). trimspace + explicit newlines:
+# a missing newline between the two PEM blocks would produce an unparseable
+# bundle.
+resource "azurerm_container_app_environment_certificate" "origin" {
+  count = length(var.custom_domains) > 0 ? 1 : 0
+
+  # The cert blob is ForceNew and stays referenced by live hostname bindings:
+  # rotation must create the replacement first (hence the fingerprint-suffixed
+  # name — two certs coexist briefly) or Azure rejects deleting an in-use cert.
+  name                         = "cf-origin-${var.environment}-${substr(sha256(var.origin_certificate_pem), 0, 8)}"
+  container_app_environment_id = azurerm_container_app_environment.this.id
+  certificate_blob_base64      = base64encode("${trimspace(var.origin_certificate_pem)}\n${trimspace(var.origin_private_key_pem)}\n")
+  certificate_password         = ""
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "azurerm_container_app_custom_domain" "this" {
+  for_each = var.custom_domains
+
+  name                                     = each.value
+  container_app_id                         = module.app.id
+  container_app_environment_certificate_id = azurerm_container_app_environment_certificate.origin[0].id
+  certificate_binding_type                 = "SniEnabled"
+
+  # Ownership validation reads the asuid TXT record.
+  depends_on = [cloudflare_dns_record.verification]
+}
+
+# Created only after the hostname is bound so guests are never routed to an
+# unbound host (ACA would 404).
+resource "cloudflare_dns_record" "host" {
+  for_each = var.custom_domains
+
+  zone_id = var.cloudflare_zone_id
+  name    = each.value
+  type    = each.value == var.cloudflare_zone_name ? "A" : "CNAME"
+  # sensitive(): the record targets are the Cloudflare-hidden origin (static IP
+  # / default FQDN) — keep them out of public plan logs, matching the env
+  # roots' sensitive outputs.
+  content = sensitive(each.value == var.cloudflare_zone_name ? azurerm_container_app_environment.this.static_ip_address : module.app.default_fqdn)
+  proxied = true
+  ttl     = 1
+
+  depends_on = [azurerm_container_app_custom_domain.this]
+}

--- a/infra/terraform/modules/env-stack/outputs.tf
+++ b/infra/terraform/modules/env-stack/outputs.tf
@@ -7,13 +7,3 @@ output "default_fqdn" {
   value       = module.app.default_fqdn
   description = "Default ingress FQDN (used for smoke tests, bypassing Cloudflare)."
 }
-
-output "custom_domain_verification_id" {
-  value       = module.app.custom_domain_verification_id
-  description = "Value for the `asuid.<host>` TXT record."
-}
-
-output "environment_static_ip" {
-  value       = azurerm_container_app_environment.this.static_ip_address
-  description = "Environment static IP — the target for the apex A record in Cloudflare."
-}

--- a/infra/terraform/modules/env-stack/variables.tf
+++ b/infra/terraform/modules/env-stack/variables.tf
@@ -63,3 +63,30 @@ variable "tags" {
   description = "Resource tags."
   default     = {}
 }
+
+variable "cloudflare_zone_id" {
+  type        = string
+  description = "Cloudflare zone ID for the DNS records."
+}
+
+variable "cloudflare_zone_name" {
+  type        = string
+  description = "Zone apex name. Hostnames equal to it get an A record to the environment static IP; others get a CNAME to the app FQDN."
+}
+
+variable "custom_domains" {
+  type        = set(string)
+  description = "Public hostnames to bind to the app (behind the Cloudflare proxy). Empty disables all custom-domain management."
+  default     = []
+}
+
+variable "origin_certificate_pem" {
+  type        = string
+  description = "Cloudflare Origin CA certificate (PEM), from the shared stack."
+}
+
+variable "origin_private_key_pem" {
+  type        = string
+  description = "Origin CA private key (PEM), from the shared stack."
+  sensitive   = true
+}

--- a/infra/terraform/modules/env-stack/versions.tf
+++ b/infra/terraform/modules/env-stack/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+  }
+}


### PR DESCRIPTION
Closes #23.

## What this does

Serves **czarnickwedding.com**, **www**, and **staging.czarnickwedding.com** through the Cloudflare proxy (Full strict) from the Azure Container Apps, entirely Terraform-managed:

- **`shared`**: Cloudflare zone lookup, zone SSL → Full (strict), 15-year Origin CA certificate (key/CSR/cert chain, `create_before_destroy` so rotation issues the replacement before revoking; hostnames in API-sorted order to avoid a ForceNew perma-diff).
- **`env-stack` module**: per-hostname `asuid.*` verification TXTs (pre-quoted, canonical v5 form), proxied host records (apex A / subdomain CNAME — record targets wrapped in `sensitive()` so the origin IP/FQDN stay out of public plan logs), Origin CA cert upload per environment (fingerprint-suffixed name), SNI hostname bindings.
- **Roots**: staging binds `staging.`; production binds apex + `www` and defaults to `min_replicas = 1` (**cost: ~$3–14/mo**, deliberate — no guest-facing cold starts; flagged in AGENTS.md).
- **Pipeline**: single `CLOUDFLARE_API_TOKEN` secret (Zone:Read, DNS:Edit, Zone Settings:Edit, SSL and Certificates:Edit — Origin CA keys are deprecated, removed by Cloudflare 2026-09-30). Lock files regenerated with `linux_amd64` + `darwin_arm64` hashes.
- **Docs**: runbook section rewritten for the automated flow (credentials, origin lock, smoke hosts, cert rotation, one-time cutover record); design spec + reviewed implementation plan in `docs/superpowers/`.

## Resolves the issue's open question

Automation over manual: everything is in Terraform via the Cloudflare provider. Trade-off accepted and documented — the Origin CA **private key lives in Terraform state** (AAD-locked storage); provider credentials are env-var-only and never persisted.

## Already applied — merge is the reconciliation

This branch was applied to live infra (zero-downtime apex cutover from the old home-server origin; origin IP-locked to Cloudflare's published ranges; smoke tests routed through the public hostnames; a full Deploy run passed both smoke tests). All three environments currently `terraform plan` as **no-ops** against this code. The post-merge Infra run (two approvals: `infra`, `production`) should therefore apply **no changes** — that no-op is the proof code and state agree.

Repo variables set as part of execution: `ALLOWED_IP_RANGES_JSON`, `STAGING_SMOKE_HOST`, `PRODUCTION_SMOKE_HOST`.

## Verification

- `terraform fmt -check -recursive`, per-env `terraform validate`, `actionlint` — all clean
- Two full code-review rounds (16 findings found, verified, and fixed) before execution
- Live: all three hostnames serve through Cloudflare under Full (strict); both default ACA FQDNs return 403; `minReplicas: 1` confirmed via `az`

🤖 Generated with [Claude Code](https://claude.com/claude-code)