### PR TITLE
Infra: Azure SQL serverless database (Terraform) (#61)

### DIFF
--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -57,17 +57,24 @@ jobs:
             || { echo "::error::Container App ${{ inputs.app_name }} not found — run the Infra workflow first."; exit 1; }
 
       # Inert until issue #62 adds prisma/schema.prisma (and the referenced
-      # scripts/ensure-db-user.mjs + db:migrate:deploy npm script). Runs migrations
-      # against this env's DB before the new image goes live, so schema never lags
-      # the code. Passwordless: az is logged in as the AAD admin (the deploy SP is
-      # a member of czw-sql-admins), so DefaultAzureCredential resolves via the CLI.
-      # #62 must also add `actions/setup-node` (from .nvmrc) + `npm ci` above this
-      # step so `node` and `npm run` have the toolchain and dependencies.
+      # Runs migrations against this env's DB before the new image goes live, so
+      # schema never lags the code. Passwordless: az is logged in as the AAD admin
+      # (the deploy SP is a member of czw-sql-admins), so DefaultAzureCredential
+      # resolves via the CLI.
+      #
+      # INERT until the CI-migration wiring lands. #62 added the Prisma schema +
+      # local-dev tooling but NOT the deploy path, so the sentinel is
+      # scripts/ensure-db-user.mjs (still absent). Activating this step means:
+      #   1. create scripts/ensure-db-user.mjs (idempotent CREATE USER ... FROM
+      #      EXTERNAL PROVIDER for the app MI, via mssql + DefaultAzureCredential),
+      #   2. add a `db:migrate:deploy` npm script (`prisma migrate deploy`),
+      #   3. add `actions/setup-node` (from .nvmrc) + `npm ci` above this step,
+      #   4. grant the deploy identity SQL firewall-rule write (bootstrap step 5).
       - name: Run database migrations
         run: |
           set -euo pipefail
-          if [ ! -f prisma/schema.prisma ]; then
-            echo "No prisma/schema.prisma yet — skipping migrations (inert until issue #62)."
+          if [ ! -f scripts/ensure-db-user.mjs ]; then
+            echo "CI-migration wiring not present (scripts/ensure-db-user.mjs) — skipping."
             exit 0
           fi
 

--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -52,6 +52,39 @@ jobs:
           az containerapp show -g "${{ inputs.resource_group }}" -n "${{ inputs.app_name }}" -o none \
             || { echo "::error::Container App ${{ inputs.app_name }} not found — run the Infra workflow first."; exit 1; }
 
+      # Inert until issue #62 adds prisma/schema.prisma (and the referenced
+      # scripts/ensure-db-user.mjs + db:migrate:deploy npm script). Runs migrations
+      # against this env's DB before the new image goes live, so schema never lags
+      # the code. Passwordless: az is logged in as the AAD admin (the deploy SP is
+      # a member of czw-sql-admins), so DefaultAzureCredential resolves via the CLI.
+      - name: Run database migrations
+        run: |
+          set -euo pipefail
+          if [ ! -f prisma/schema.prisma ]; then
+            echo "No prisma/schema.prisma yet — skipping migrations (inert until issue #62)."
+            exit 0
+          fi
+
+          ENV_SUFFIX="${{ inputs.resource_group }}"; ENV_SUFFIX="${ENV_SUFFIX#rg-czw-}"
+          SERVER="sql-czw-${ENV_SUFFIX}"
+          APP_IDENTITY="id-czw-app-${ENV_SUFFIX}"
+          RG="${{ inputs.resource_group }}"
+
+          # Open the SQL firewall to this runner for the duration of the job.
+          RUNNER_IP=$(curl -fsS https://api.ipify.org)
+          RULE="ci-migrate-${GITHUB_RUN_ID}"
+          az sql server firewall-rule create -g "$RG" -s "$SERVER" -n "$RULE" \
+            --start-ip-address "$RUNNER_IP" --end-ip-address "$RUNNER_IP" -o none
+          trap 'az sql server firewall-rule delete -g "$RG" -s "$SERVER" -n "$RULE" -o none || true' EXIT
+
+          export DATABASE_URL="sqlserver://${SERVER}.database.windows.net:1433;database=rsvp;authentication=DefaultAzureCredential;encrypt=true"
+
+          # Idempotently grant the app's managed identity DB access, then migrate.
+          node scripts/ensure-db-user.mjs "$APP_IDENTITY"
+          npm run --silent db:migrate:deploy
+        env:
+          NODE_ENV: production
+
       - name: Deploy image
         run: az containerapp update -g "${{ inputs.resource_group }}" -n "${{ inputs.app_name }}" --image "${{ inputs.image }}" -o none
 

--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -41,6 +41,10 @@ jobs:
     env:
       SMOKE_STRING: "October 10, 2026"
     steps:
+      # Needed so the migrate step below can see prisma/schema.prisma; deploy
+      # itself is repo-free (pure az CLI), but the migration guard reads the tree.
+      - uses: actions/checkout@v7
+
       - uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_DEPLOY_CLIENT_ID }}
@@ -57,6 +61,8 @@ jobs:
       # against this env's DB before the new image goes live, so schema never lags
       # the code. Passwordless: az is logged in as the AAD admin (the deploy SP is
       # a member of czw-sql-admins), so DefaultAzureCredential resolves via the CLI.
+      # #62 must also add `actions/setup-node` (from .nvmrc) + `npm ci` above this
+      # step so `node` and `npm run` have the toolchain and dependencies.
       - name: Run database migrations
         run: |
           set -euo pipefail

--- a/.github/workflows/_deploy-env.yml
+++ b/.github/workflows/_deploy-env.yml
@@ -41,10 +41,6 @@ jobs:
     env:
       SMOKE_STRING: "October 10, 2026"
     steps:
-      # Needed so the migrate step below can see prisma/schema.prisma; deploy
-      # itself is repo-free (pure az CLI), but the migration guard reads the tree.
-      - uses: actions/checkout@v7
-
       - uses: azure/login@v3
         with:
           client-id: ${{ vars.AZURE_DEPLOY_CLIENT_ID }}
@@ -56,47 +52,48 @@ jobs:
           az containerapp show -g "${{ inputs.resource_group }}" -n "${{ inputs.app_name }}" -o none \
             || { echo "::error::Container App ${{ inputs.app_name }} not found — run the Infra workflow first."; exit 1; }
 
-      # Inert until issue #62 adds prisma/schema.prisma (and the referenced
+      # Migrations are gated on the ENABLE_DB_MIGRATIONS repo variable, not merged
+      # "on". Turn it to 'true' once (a) the SQL servers exist (first Infra apply),
+      # (b) the deploy SP is in czw-sql-admins, and (c) it has SQL firewall-rule
+      # write — see docs/deployment/README.md. Off = deploy is pure az CLI, unchanged.
+      - uses: actions/checkout@v7
+        if: ${{ vars.ENABLE_DB_MIGRATIONS == 'true' }}
+      - uses: actions/setup-node@v4
+        if: ${{ vars.ENABLE_DB_MIGRATIONS == 'true' }}
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - name: Install dependencies
+        if: ${{ vars.ENABLE_DB_MIGRATIONS == 'true' }}
+        run: npm ci
+
       # Runs migrations against this env's DB before the new image goes live, so
       # schema never lags the code. Passwordless: az is logged in as the AAD admin
-      # (the deploy SP is a member of czw-sql-admins), so DefaultAzureCredential
-      # resolves via the CLI.
-      #
-      # INERT until the CI-migration wiring lands. #62 added the Prisma schema +
-      # local-dev tooling but NOT the deploy path, so the sentinel is
-      # scripts/ensure-db-user.mjs (still absent). Activating this step means:
-      #   1. create scripts/ensure-db-user.mjs (idempotent CREATE USER ... FROM
-      #      EXTERNAL PROVIDER for the app MI, via mssql + DefaultAzureCredential),
-      #   2. add a `db:migrate:deploy` npm script (`prisma migrate deploy`),
-      #   3. add `actions/setup-node` (from .nvmrc) + `npm ci` above this step,
-      #   4. grant the deploy identity SQL firewall-rule write (bootstrap step 5).
+      # (the deploy SP is a member of czw-sql-admins), so azure-active-directory-
+      # default / DefaultAzureCredential resolves via the CLI session.
       - name: Run database migrations
+        if: ${{ vars.ENABLE_DB_MIGRATIONS == 'true' }}
+        env:
+          NODE_ENV: production
+          SQL_DATABASE: rsvp
         run: |
           set -euo pipefail
-          if [ ! -f scripts/ensure-db-user.mjs ]; then
-            echo "CI-migration wiring not present (scripts/ensure-db-user.mjs) — skipping."
-            exit 0
-          fi
-
           ENV_SUFFIX="${{ inputs.resource_group }}"; ENV_SUFFIX="${ENV_SUFFIX#rg-czw-}"
           SERVER="sql-czw-${ENV_SUFFIX}"
-          APP_IDENTITY="id-czw-app-${ENV_SUFFIX}"
           RG="${{ inputs.resource_group }}"
+          export SQL_SERVER="${SERVER}.database.windows.net"
 
           # Open the SQL firewall to this runner for the duration of the job.
           RUNNER_IP=$(curl -fsS https://api.ipify.org)
-          RULE="ci-migrate-${GITHUB_RUN_ID}"
+          RULE="ci-migrate-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           az sql server firewall-rule create -g "$RG" -s "$SERVER" -n "$RULE" \
             --start-ip-address "$RUNNER_IP" --end-ip-address "$RUNNER_IP" -o none
           trap 'az sql server firewall-rule delete -g "$RG" -s "$SERVER" -n "$RULE" -o none || true' EXIT
 
-          export DATABASE_URL="sqlserver://${SERVER}.database.windows.net:1433;database=rsvp;authentication=DefaultAzureCredential;encrypt=true"
-
           # Idempotently grant the app's managed identity DB access, then migrate.
-          node scripts/ensure-db-user.mjs "$APP_IDENTITY"
+          node scripts/ensure-db-user.mjs "id-czw-app-${ENV_SUFFIX}"
+          export DATABASE_URL="sqlserver://${SQL_SERVER}:1433;database=rsvp;authentication=DefaultAzureCredential;encrypt=true"
           npm run --silent db:migrate:deploy
-        env:
-          NODE_ENV: production
 
       - name: Deploy image
         run: az containerapp update -g "${{ inputs.resource_group }}" -n "${{ inputs.app_name }}" --image "${{ inputs.image }}" -o none

--- a/.github/workflows/_terraform-env.yml
+++ b/.github/workflows/_terraform-env.yml
@@ -46,6 +46,14 @@ jobs:
       # Origin lock lives in a repo variable, not a gitignored tfvars, so the
       # pipeline never reverts it. Defaults to [] (open) until you set it.
       TF_VAR_allowed_ip_ranges: ${{ vars.ALLOWED_IP_RANGES_JSON || '[]' }}
+      # SQL server AAD admin (the czw-sql-admins Entra group). Set by object ID so
+      # the RG-Contributor infra identity needs no directory permission.
+      TF_VAR_sql_admin_group_object_id: ${{ vars.SQL_AAD_ADMIN_GROUP_OBJECT_ID }}
+      TF_VAR_sql_admin_group_name: ${{ vars.SQL_AAD_ADMIN_GROUP_NAME }}
+      TF_VAR_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+      # Empty until issue #63 registers the OAuth app and sets these secrets.
+      TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID || '' }}
+      TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET || '' }}
       # Cloudflare provider auth — a single zone-scoped API token; required
       # scopes documented in docs/deployment/README.md (Custom domains).
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -260,10 +260,14 @@ variable **`ADMIN_EMAIL_ALLOWLIST`** (comma-separated emails), set by hand.
 ### Migrations
 
 `deploy.yml` runs `prisma migrate deploy` against each env's DB before promoting
-the image. The step is **inert until the Prisma schema lands** (it early-exits
-when `prisma/schema.prisma` is absent). To activate it, issue #62 must add
-`actions/setup-node` + `npm ci` to the deploy job and create
-`scripts/ensure-db-user.mjs` + the `db:migrate:deploy` npm script. The deploy
-identity also needs **SQL firewall-rule write** on the staging + production SQL
-servers (the migrate job opens/closes its runner IP) — see manual step 5 in the
-bootstrap output.
+the image. The step is **inert until the CI-migration wiring lands** — it
+early-exits when `scripts/ensure-db-user.mjs` is absent. #62 added the Prisma
+schema + local-dev tooling but not the deploy path, so activating this step is a
+separate follow-up:
+
+1. create `scripts/ensure-db-user.mjs` (idempotent `CREATE USER ... FROM EXTERNAL
+   PROVIDER` for the app identity, via `mssql` + `DefaultAzureCredential`);
+2. add a `db:migrate:deploy` npm script (`prisma migrate deploy`);
+3. add `actions/setup-node` + `npm ci` to the deploy job;
+4. grant the deploy identity **SQL firewall-rule write** on the staging +
+   production SQL servers — see manual step 5 in the bootstrap output.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -219,12 +219,49 @@ az group delete -n rg-czw-identity -y
 az group delete -n rg-czw-tfstate  -y
 ```
 
-## Future: RSVP API + database
+## RSVP database (Azure SQL)
 
-The environments are Workload-Profiles (v2), so you can add a second Container
-App (the API) into the same environment and attach an Azure Database for
-PostgreSQL (Flexible Server, burstable B1ms is the cheap tier) with private
-networking. Add its Terraform to the `env-stack` module and wire connection
-settings through Container App secrets — do **not** put secrets in `.tfvars`
-(state holds them in cleartext; the state account is AAD-locked but treat it
-accordingly).
+The RSVP feature uses an **Azure SQL logical server + one serverless database
+(`rsvp`) per environment**, provisioned by the `sql-database` module inside
+`env-stack`. No new compute: the existing Container App reaches it.
+
+**Passwordless by design.** The server is **AAD-only**
+(`azuread_authentication_only = true`) — no SQL login/password exists anywhere.
+The app connects with its per-env user-assigned identity
+(`id-czw-app-<env>`) via `authentication=ActiveDirectoryManagedIdentity`; there
+is no secret in state or in Container App config. Because no password login
+exists, the public endpoint is not anonymously usable — every connection needs a
+valid Entra token from an authorised principal.
+
+**Cost:** staging auto-pauses after 60 min idle (~$5/mo storage floor);
+production runs warm (auto-pause disabled, min 0.5 vCore) to avoid a first-query
+resume delay (~$15–30/mo). This is a deliberate trade against the "~$5/mo idle
+floor" — consistent with production's warm `min_replicas = 1` policy.
+
+### Prerequisites (set by `bootstrap-azure.sh`)
+
+- Entra group **`czw-sql-admins`** is the server's AAD admin. It must contain the
+  human admin(s) and the **deploy** identity (so CI migrations authenticate as
+  admin via OIDC). Creating the group needs a directory role (e.g. Groups
+  Administrator); if bootstrap can't create it, make it by hand.
+- Repo variables **`SQL_AAD_ADMIN_GROUP_OBJECT_ID`** and
+  **`SQL_AAD_ADMIN_GROUP_NAME`** (Terraform sets the AAD admin by object id, so
+  the RG-Contributor infra identity needs no directory permission). These must
+  exist **before** the first `infra` apply or the plan fails on an unset var.
+
+### Auth.js secret plumbing (scaffolded here, filled by the auth issue)
+
+Terraform generates `AUTH_SECRET` and wires the Container App env. The Google
+OAuth secrets (`google-client-id` / `google-client-secret`) are defined but
+**empty** — supplied later via the `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET`
+GitHub secrets once the OAuth app exists. The admin allowlist is a GitHub repo
+variable **`ADMIN_EMAIL_ALLOWLIST`** (comma-separated emails), set by hand.
+
+### Migrations
+
+`deploy.yml` runs `prisma migrate deploy` against each env's DB before promoting
+the image. The step is **inert until the Prisma schema lands** (it early-exits
+when `prisma/schema.prisma` is absent). When migrations go live, the deploy
+identity also needs **SQL firewall-rule write** on the staging + production SQL
+servers (the migrate job opens/closes its runner IP) — see manual step 5 in the
+bootstrap output.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -261,7 +261,9 @@ variable **`ADMIN_EMAIL_ALLOWLIST`** (comma-separated emails), set by hand.
 
 `deploy.yml` runs `prisma migrate deploy` against each env's DB before promoting
 the image. The step is **inert until the Prisma schema lands** (it early-exits
-when `prisma/schema.prisma` is absent). When migrations go live, the deploy
+when `prisma/schema.prisma` is absent). To activate it, issue #62 must add
+`actions/setup-node` + `npm ci` to the deploy job and create
+`scripts/ensure-db-user.mjs` + the `db:migrate:deploy` npm script. The deploy
 identity also needs **SQL firewall-rule write** on the staging + production SQL
 servers (the migrate job opens/closes its runner IP) — see manual step 5 in the
 bootstrap output.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -260,14 +260,22 @@ variable **`ADMIN_EMAIL_ALLOWLIST`** (comma-separated emails), set by hand.
 ### Migrations
 
 `deploy.yml` runs `prisma migrate deploy` against each env's DB before promoting
-the image. The step is **inert until the CI-migration wiring lands** — it
-early-exits when `scripts/ensure-db-user.mjs` is absent. #62 added the Prisma
-schema + local-dev tooling but not the deploy path, so activating this step is a
-separate follow-up:
+the image, so schema never lags the code. The full path is wired
+(`scripts/ensure-db-user.mjs` grants the app identity least-privilege
+read/write; `db:migrate:deploy` applies migrations), but it is **gated on the
+`ENABLE_DB_MIGRATIONS` repo variable** and off by default — a deploy with it
+unset is pure `az` CLI, exactly as before.
 
-1. create `scripts/ensure-db-user.mjs` (idempotent `CREATE USER ... FROM EXTERNAL
-   PROVIDER` for the app identity, via `mssql` + `DefaultAzureCredential`);
-2. add a `db:migrate:deploy` npm script (`prisma migrate deploy`);
-3. add `actions/setup-node` + `npm ci` to the deploy job;
-4. grant the deploy identity **SQL firewall-rule write** on the staging +
-   production SQL servers — see manual step 5 in the bootstrap output.
+**Turning migrations on** (once, after the first `staging` apply creates the
+server):
+
+```bash
+gh variable set ENABLE_DB_MIGRATIONS --body true
+```
+
+`bootstrap-azure.sh` has already granted the deploy identity `SQL Server
+Contributor` on the app RGs (to open/close a transient firewall rule for the
+runner IP — GitHub runners aren't "Azure services") and added it to
+`czw-sql-admins` (to authenticate as the AAD admin). The migrate job authenticates
+passwordlessly via the runner's `az login` session. Migrations run per env in the
+promote order: staging → (approval) → production.

--- a/docs/superpowers/plans/2026-07-17-azure-sql-serverless-infra.md
+++ b/docs/superpowers/plans/2026-07-17-azure-sql-serverless-infra.md
@@ -1,0 +1,702 @@
+# Azure SQL Serverless Database (Terraform) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provision an Azure SQL logical server + one serverless database per environment in Terraform, reachable passwordlessly from the Container App via managed identity, with Auth.js secret plumbing scaffolded and an (inert-until-#62) migrate step added to CI.
+
+**Architecture:** A new reusable `sql-database` Terraform module is instantiated per-env by `env-stack`. The `container-app` module gains additive inputs (extra identities, env vars, secrets) so the app carries a per-env user-assigned identity and DB/auth env wiring. A guarded migrate job in `deploy.yml` runs `prisma migrate deploy` (and a one-time DB-user grant) once the Prisma schema lands.
+
+**Tech Stack:** Terraform (`hashicorp/azurerm ~> 4.0`, `hashicorp/random`), Azure SQL serverless (`GP_S_Gen5_1`), Azure Container Apps, GitHub Actions.
+
+## Global Constraints
+
+- Terraform provider: `hashicorp/azurerm` version `~> 4.0`; `required_version >= 1.9`. New module needs `hashicorp/random`.
+- Every `*.tf` change must pass `terraform fmt -check -recursive infra/terraform`.
+- Per-env gate: `terraform -chdir=infra/terraform/environments/<env> init -backend=false && terraform validate` (staging + production).
+- Workflow changes must pass `actionlint`.
+- Repo gate must stay green: `npm run lint && npm run build && npm run check:images`.
+- Resource naming convention: `<type>-czw-<env>` (e.g. `sql-czw-staging`, `id-czw-app-staging`). DB name is `rsvp`.
+- DB auth is **passwordless** — no SQL admin login/password anywhere. Server is AAD-only.
+- CI passes environment values as `TF_VAR_*` in `_terraform-env.yml` (never local tfvars).
+- Do **not** run `terraform apply` from this branch; `infra.yml` applies on merge.
+
+---
+
+### Task 1: `sql-database` Terraform module
+
+**Files:**
+- Create: `infra/terraform/modules/sql-database/versions.tf`
+- Create: `infra/terraform/modules/sql-database/variables.tf`
+- Create: `infra/terraform/modules/sql-database/main.tf`
+- Create: `infra/terraform/modules/sql-database/outputs.tf`
+
+**Interfaces:**
+- Consumes (module inputs): `environment (string)`, `location (string)`, `resource_group_name (string)`, `aad_admin_login (string)`, `aad_admin_object_id (string)`, `tenant_id (string)`, `auto_pause_delay_in_minutes (number)`, `tags (map(string))`.
+- Produces (module outputs): `server_fqdn (string)`, `database_name (string)`.
+
+- [ ] **Step 1: Write `versions.tf`**
+
+```hcl
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Write `variables.tf`**
+
+```hcl
+variable "environment" {
+  type        = string
+  description = "Environment name (staging|production). Used in resource names."
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the SQL server and database."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group that hosts the SQL server."
+}
+
+variable "aad_admin_login" {
+  type        = string
+  description = "Display name of the Entra principal set as the server's AAD admin (e.g. the czw-sql-admins group)."
+}
+
+variable "aad_admin_object_id" {
+  type        = string
+  description = "Object ID of the Entra admin principal. Set by object ID so an RG-Contributor CI identity needs no Graph permission."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Entra tenant ID for the AAD administrator."
+}
+
+variable "auto_pause_delay_in_minutes" {
+  type        = number
+  description = "Serverless auto-pause idle delay. 60 = pause after 1h idle; -1 = never pause (warm)."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Resource tags."
+  default     = {}
+}
+```
+
+- [ ] **Step 3: Write `main.tf`**
+
+```hcl
+# AAD-only server: no SQL login/password exists, so a public endpoint is not
+# anonymously usable — every connection needs a valid Entra token from an
+# authorized principal.
+resource "azurerm_mssql_server" "this" {
+  name                          = "sql-czw-${var.environment}"
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  version                       = "12.0"
+  minimum_tls_version           = "1.2"
+  public_network_access_enabled = true
+
+  azuread_administrator {
+    login_username              = var.aad_admin_login
+    object_id                   = var.aad_admin_object_id
+    tenant_id                   = var.tenant_id
+    azuread_authentication_only = true
+  }
+
+  tags = var.tags
+}
+
+# Serverless General Purpose. min_capacity 0.5 vCore floor; storage LRS (Local)
+# since the guest list is re-seedable and does not need geo-redundant backups.
+resource "azurerm_mssql_database" "rsvp" {
+  name                        = "rsvp"
+  server_id                   = azurerm_mssql_server.this.id
+  sku_name                    = "GP_S_Gen5_1"
+  min_capacity                = 0.5
+  max_size_gb                 = 2
+  auto_pause_delay_in_minutes = var.auto_pause_delay_in_minutes
+  storage_account_type        = "Local"
+
+  tags = var.tags
+}
+
+# Lets the Container App (Azure outbound) reach the server. The 0.0.0.0 rule is
+# Azure's "Allow all Azure services" convention. Non-Azure clients (e.g. the CI
+# runner) add their own IP transiently in the migrate job.
+resource "azurerm_mssql_firewall_rule" "allow_azure_services" {
+  name             = "AllowAllAzureServices"
+  server_id        = azurerm_mssql_server.this.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+```
+
+- [ ] **Step 4: Write `outputs.tf`**
+
+```hcl
+output "server_fqdn" {
+  value       = azurerm_mssql_server.this.fully_qualified_domain_name
+  description = "SQL server FQDN, used to build the app connection string."
+}
+
+output "database_name" {
+  value       = azurerm_mssql_database.rsvp.name
+  description = "Database name (rsvp)."
+}
+```
+
+- [ ] **Step 5: Format + validate the module standalone**
+
+Run:
+```bash
+cd infra/terraform/modules/sql-database
+terraform fmt
+terraform init -backend=false && terraform validate
+```
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add infra/terraform/modules/sql-database
+git commit -m "feat(infra): add sql-database module (AAD-only serverless DB) (#61)"
+```
+
+---
+
+### Task 2: Extend `container-app` module (identities, env, secrets)
+
+**Files:**
+- Modify: `infra/terraform/modules/container-app/variables.tf`
+- Modify: `infra/terraform/modules/container-app/main.tf`
+
+**Interfaces:**
+- Consumes: existing inputs unchanged.
+- Produces (new inputs, all default empty → backward-compatible): `additional_identity_ids (list(string))`, `extra_env (list(object({ name=string, value=string })))`, `secrets (list(object({ name=string, value=string })))`, `secret_env (list(object({ name=string, secret_name=string })))`.
+
+- [ ] **Step 1: Append new variables to `variables.tf`**
+
+```hcl
+variable "additional_identity_ids" {
+  type        = list(string)
+  description = "Extra user-assigned identity IDs to attach (e.g. the app's DB identity), merged with the AcrPull identity."
+  default     = []
+}
+
+variable "extra_env" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "Plain (non-secret) environment variables appended to the container."
+  default     = []
+}
+
+variable "secrets" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "Container App secrets. Empty-valued entries must be filtered out by the caller (ACA rejects empty secret values)."
+  default     = []
+}
+
+variable "secret_env" {
+  type = list(object({
+    name        = string
+    secret_name = string
+  }))
+  description = "Environment variables that reference a secret by name (secret_ref)."
+  default     = []
+}
+```
+
+- [ ] **Step 2: Merge identities in `main.tf`**
+
+Replace the `identity` block:
+```hcl
+  identity {
+    type         = "UserAssigned"
+    identity_ids = concat([var.acr_pull_identity_id], var.additional_identity_ids)
+  }
+```
+
+- [ ] **Step 3: Add secret blocks + wire env in `main.tf`**
+
+Add secret blocks at the top of the `resource "azurerm_container_app" "this"` body (after `identity` / `registry`, before `ingress` is fine — ACA `secret` is a top-level block):
+```hcl
+  dynamic "secret" {
+    for_each = { for s in var.secrets : s.name => s.value }
+    content {
+      name  = secret.key
+      value = secret.value
+    }
+  }
+```
+
+Inside `template.container`, after the existing `NODE_ENV` `env` block, append:
+```hcl
+      dynamic "env" {
+        for_each = { for e in var.extra_env : e.name => e.value }
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      dynamic "env" {
+        for_each = { for e in var.secret_env : e.name => e.secret_name }
+        content {
+          name        = env.key
+          secret_name = env.value
+        }
+      }
+```
+
+- [ ] **Step 4: Format + validate**
+
+Run:
+```bash
+cd infra/terraform/modules/container-app
+terraform fmt
+terraform init -backend=false && terraform validate
+```
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/terraform/modules/container-app
+git commit -m "feat(infra): container-app supports extra identities, env, and secrets (#61)"
+```
+
+---
+
+### Task 3: Wire the database + auth scaffold into `env-stack`
+
+**Files:**
+- Modify: `infra/terraform/modules/env-stack/versions.tf`
+- Modify: `infra/terraform/modules/env-stack/variables.tf`
+- Modify: `infra/terraform/modules/env-stack/main.tf`
+- Modify: `infra/terraform/modules/env-stack/outputs.tf`
+
+**Interfaces:**
+- Consumes: `sql-database` module (Task 1), extended `container-app` module (Task 2).
+- Produces (new env-stack inputs): `sql_admin_group_name (string)`, `sql_admin_group_object_id (string)`, `tenant_id (string)`, `db_auto_pause_delay_in_minutes (number)`, `google_client_id (string, default "")`, `google_client_secret (string, default "")`. New output: `sql_server_fqdn (string)`.
+
+- [ ] **Step 1: Add the `random` provider to `versions.tf`**
+
+```hcl
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 5.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Append new variables to `variables.tf`**
+
+```hcl
+variable "sql_admin_group_name" {
+  type        = string
+  description = "Display name of the Entra group set as the SQL server AAD admin (contains human admins + the CI deploy SP)."
+}
+
+variable "sql_admin_group_object_id" {
+  type        = string
+  description = "Object ID of the SQL admin Entra group."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Entra tenant ID."
+}
+
+variable "db_auto_pause_delay_in_minutes" {
+  type        = number
+  description = "Serverless auto-pause delay. 60 for staging (pause when idle); -1 for production (stay warm)."
+}
+
+variable "google_client_id" {
+  type        = string
+  description = "Google OAuth client ID for Auth.js. Empty until issue #63 supplies it."
+  default     = ""
+}
+
+variable "google_client_secret" {
+  type        = string
+  description = "Google OAuth client secret for Auth.js. Empty until issue #63 supplies it."
+  default     = ""
+  sensitive   = true
+}
+```
+
+- [ ] **Step 3: Add DB, app identity, secret plumbing, and DB wiring to `main.tf`**
+
+Append to `main.tf` (the existing `data.azurerm_resource_group.env`, `azurerm_container_app_environment.this`, and `module.app` stay; the `module.app` call is edited in Step 4):
+
+```hcl
+# Per-env identity the app uses for passwordless (managed identity) DB access.
+# Granted inside the database (CREATE USER ... FROM EXTERNAL PROVIDER) by the CI
+# migrate job, not by Terraform (no azurerm resource for contained DB users).
+resource "azurerm_user_assigned_identity" "app" {
+  name                = "id-czw-app-${var.environment}"
+  location            = data.azurerm_resource_group.env.location
+  resource_group_name = data.azurerm_resource_group.env.name
+  tags                = var.tags
+}
+
+module "database" {
+  source = "../sql-database"
+
+  environment                 = var.environment
+  location                    = data.azurerm_resource_group.env.location
+  resource_group_name         = data.azurerm_resource_group.env.name
+  aad_admin_login             = var.sql_admin_group_name
+  aad_admin_object_id         = var.sql_admin_group_object_id
+  tenant_id                   = var.tenant_id
+  auto_pause_delay_in_minutes = var.db_auto_pause_delay_in_minutes
+  tags                        = var.tags
+}
+
+# Auth.js session secret — generated, never hand-managed. Base64 of 32 bytes.
+resource "random_id" "auth_secret" {
+  byte_length = 32
+}
+
+locals {
+  database_url = "sqlserver://${module.database.server_fqdn}:1433;database=${module.database.database_name};authentication=ActiveDirectoryManagedIdentity;clientId=${azurerm_user_assigned_identity.app.client_id};encrypt=true"
+
+  # ACA rejects empty secret values, so OAuth secrets appear only once #63
+  # supplies real values. AUTH_SECRET is always present (generated).
+  app_secrets = concat(
+    [{ name = "auth-secret", value = random_id.auth_secret.b64_std }],
+    var.google_client_id == "" ? [] : [{ name = "google-client-id", value = var.google_client_id }],
+    var.google_client_secret == "" ? [] : [{ name = "google-client-secret", value = var.google_client_secret }],
+  )
+
+  app_secret_env = concat(
+    [{ name = "AUTH_SECRET", secret_name = "auth-secret" }],
+    var.google_client_id == "" ? [] : [{ name = "AUTH_GOOGLE_ID", secret_name = "google-client-id" }],
+    var.google_client_secret == "" ? [] : [{ name = "AUTH_GOOGLE_SECRET", secret_name = "google-client-secret" }],
+  )
+}
+```
+
+- [ ] **Step 4: Pass the new wiring into the `module "app"` call in `main.tf`**
+
+Add these arguments to the existing `module "app"` block:
+```hcl
+  additional_identity_ids = [azurerm_user_assigned_identity.app.id]
+  extra_env               = [{ name = "DATABASE_URL", value = local.database_url }]
+  secrets                 = local.app_secrets
+  secret_env              = local.app_secret_env
+```
+
+- [ ] **Step 5: Add the server FQDN output to `outputs.tf`**
+
+```hcl
+output "sql_server_fqdn" {
+  value       = module.database.server_fqdn
+  description = "SQL server FQDN for the environment."
+}
+```
+
+- [ ] **Step 6: Format + validate the module standalone**
+
+Run:
+```bash
+cd infra/terraform/modules/env-stack
+terraform fmt
+terraform init -backend=false && terraform validate
+```
+Expected: `Success! The configuration is valid.`
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add infra/terraform/modules/env-stack
+git commit -m "feat(infra): wire serverless DB + app identity + auth secret scaffold into env-stack (#61)"
+```
+
+---
+
+### Task 4: Pass new variables through the staging + production roots
+
+**Files:**
+- Modify: `infra/terraform/environments/staging/main.tf`
+- Modify: `infra/terraform/environments/staging/variables.tf`
+- Modify: `infra/terraform/environments/production/main.tf`
+- Modify: `infra/terraform/environments/production/variables.tf`
+
+**Interfaces:**
+- Consumes: `env-stack` new inputs (Task 3).
+- Produces: root variables `sql_admin_group_name`, `sql_admin_group_object_id`, `tenant_id`, `google_client_id`, `google_client_secret` (fed by CI as `TF_VAR_*`).
+
+- [ ] **Step 1: Add the shared root variables to BOTH `staging/variables.tf` and `production/variables.tf`**
+
+```hcl
+variable "sql_admin_group_name" {
+  type        = string
+  description = "Display name of the Entra group set as the SQL server AAD admin."
+}
+
+variable "sql_admin_group_object_id" {
+  type        = string
+  description = "Object ID of the SQL admin Entra group."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Entra tenant ID."
+}
+
+variable "google_client_id" {
+  type        = string
+  description = "Google OAuth client ID for Auth.js. Empty until issue #63."
+  default     = ""
+}
+
+variable "google_client_secret" {
+  type        = string
+  description = "Google OAuth client secret for Auth.js. Empty until issue #63."
+  default     = ""
+  sensitive   = true
+}
+```
+
+- [ ] **Step 2: Pass them into the `module "stack"` call in `staging/main.tf`**
+
+Add to the existing `module "stack"` block, with staging's auto-pause = 60:
+```hcl
+  sql_admin_group_name           = var.sql_admin_group_name
+  sql_admin_group_object_id      = var.sql_admin_group_object_id
+  tenant_id                      = var.tenant_id
+  db_auto_pause_delay_in_minutes = 60
+  google_client_id               = var.google_client_id
+  google_client_secret           = var.google_client_secret
+```
+
+- [ ] **Step 3: Pass them into the `module "stack"` call in `production/main.tf`**
+
+Add to the existing `module "stack"` block, with production's auto-pause = -1 (warm):
+```hcl
+  sql_admin_group_name           = var.sql_admin_group_name
+  sql_admin_group_object_id      = var.sql_admin_group_object_id
+  tenant_id                      = var.tenant_id
+  db_auto_pause_delay_in_minutes = -1
+  google_client_id               = var.google_client_id
+  google_client_secret           = var.google_client_secret
+```
+
+- [ ] **Step 4: Format + validate BOTH roots (the integration gate)**
+
+Run:
+```bash
+cd infra/terraform
+terraform fmt -recursive
+terraform -chdir=environments/staging init -backend=false && terraform -chdir=environments/staging validate
+terraform -chdir=environments/production init -backend=false && terraform -chdir=environments/production validate
+```
+Expected: `Success! The configuration is valid.` for both.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add infra/terraform/environments
+git commit -m "feat(infra): pass SQL admin + auth vars through staging/production roots (#61)"
+```
+
+---
+
+### Task 5: Feed the new `TF_VAR_*` values from CI
+
+**Files:**
+- Modify: `.github/workflows/_terraform-env.yml:35-51` (the `env:` block)
+
+**Interfaces:**
+- Consumes: GitHub repo variables `SQL_AAD_ADMIN_GROUP_OBJECT_ID`, `SQL_AAD_ADMIN_GROUP_NAME`, `AZURE_TENANT_ID` (exists); optional secrets `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` (empty until #63).
+
+- [ ] **Step 1: Append to the `env:` map in `_terraform-env.yml`**
+
+```yaml
+      TF_VAR_sql_admin_group_object_id: ${{ vars.SQL_AAD_ADMIN_GROUP_OBJECT_ID }}
+      TF_VAR_sql_admin_group_name: ${{ vars.SQL_AAD_ADMIN_GROUP_NAME }}
+      TF_VAR_tenant_id: ${{ vars.AZURE_TENANT_ID }}
+      # Empty until issue #63 registers the OAuth app and sets these secrets.
+      TF_VAR_google_client_id: ${{ secrets.GOOGLE_CLIENT_ID || '' }}
+      TF_VAR_google_client_secret: ${{ secrets.GOOGLE_CLIENT_SECRET || '' }}
+```
+
+- [ ] **Step 2: Lint the workflow**
+
+Run: `actionlint .github/workflows/_terraform-env.yml`
+Expected: no output (clean).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/_terraform-env.yml
+git commit -m "ci(infra): pass SQL admin + Google OAuth TF vars (#61)"
+```
+
+---
+
+### Task 6: Guarded `prisma migrate deploy` in the deploy pipeline
+
+**Files:**
+- Modify: `.github/workflows/_deploy-env.yml` (add a migrate step before "Deploy image")
+
+**Interfaces:**
+- Consumes: existing inputs `resource_group`, `app_name`; derives server (`sql-czw-<env>`) and app identity (`id-czw-app-<env>`) names from the env suffix of `resource_group` (`rg-czw-<env>`).
+- Produces: nothing downstream; inert until `prisma/schema.prisma` exists.
+
+- [ ] **Step 1: Add a migrate step to `_deploy-env.yml` after "Assert app exists" and before "Deploy image"**
+
+```yaml
+      - name: Run database migrations
+        run: |
+          set -euo pipefail
+          if [ ! -f prisma/schema.prisma ]; then
+            echo "No prisma/schema.prisma yet — skipping migrations (inert until issue #62)."
+            exit 0
+          fi
+
+          ENV_SUFFIX="${{ inputs.resource_group }}"; ENV_SUFFIX="${ENV_SUFFIX#rg-czw-}"
+          SERVER="sql-czw-${ENV_SUFFIX}"
+          APP_IDENTITY="id-czw-app-${ENV_SUFFIX}"
+          RG="${{ inputs.resource_group }}"
+
+          # Open the SQL firewall to this runner for the duration of the job.
+          RUNNER_IP=$(curl -fsS https://api.ipify.org)
+          RULE="ci-migrate-${GITHUB_RUN_ID}"
+          az sql server firewall-rule create -g "$RG" -s "$SERVER" -n "$RULE" \
+            --start-ip-address "$RUNNER_IP" --end-ip-address "$RUNNER_IP" -o none
+          trap 'az sql server firewall-rule delete -g "$RG" -s "$SERVER" -n "$RULE" -o none || true' EXIT
+
+          # Passwordless: az is logged in as the AAD admin (deploy SP is a member
+          # of czw-sql-admins), so DefaultAzureCredential resolves via AzureCliCredential.
+          export DATABASE_URL="sqlserver://${SERVER}.database.windows.net:1433;database=rsvp;authentication=DefaultAzureCredential;encrypt=true"
+
+          # Idempotently grant the app's managed identity DB access.
+          node scripts/ensure-db-user.mjs "$APP_IDENTITY"
+
+          npm run --silent db:migrate:deploy
+        env:
+          NODE_ENV: production
+```
+
+- [ ] **Step 2: Note the two guarded dependencies for issue #62 (documentation-only in this task)**
+
+The step references `scripts/ensure-db-user.mjs` and the `db:migrate:deploy` npm script. Both are **created by issue #62** (which introduces Prisma + the `mssql` driver). Until `prisma/schema.prisma` exists the step returns early, so CI stays green now. Add a one-line note to the PR body and to the design spec's "inert until #62" section — no file created here.
+
+- [ ] **Step 3: Lint the workflow**
+
+Run: `actionlint .github/workflows/_deploy-env.yml`
+Expected: no output (clean).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/_deploy-env.yml
+git commit -m "ci(deploy): guarded prisma migrate deploy step (inert until #62) (#61)"
+```
+
+---
+
+### Task 7: Operational docs — Entra admin group + repo variables
+
+**Files:**
+- Modify: `scripts/bootstrap-azure.sh` (add an idempotent block creating the group + repo vars, or a clearly-marked manual section if the script is Owner-run interactive)
+- Modify: `docs/deployment/README.md` (RSVP database prerequisites subsection)
+
+**Interfaces:** none (docs/ops).
+
+- [ ] **Step 1: Read the current bootstrap script + README deployment doc to match their style**
+
+Run: `sed -n '1,60p' scripts/bootstrap-azure.sh` and skim `docs/deployment/README.md` headings.
+
+- [ ] **Step 2: Add a bootstrap block for the SQL admin group**
+
+Add an idempotent section that: creates Entra group `czw-sql-admins`; adds the human admin(s) and the CI **deploy** service principal as members; sets GitHub repo variables `SQL_AAD_ADMIN_GROUP_OBJECT_ID` and `SQL_AAD_ADMIN_GROUP_NAME`. Use the script's existing `az ad group` / `gh variable set` idioms. Example core commands:
+
+```bash
+GROUP_NAME="czw-sql-admins"
+GROUP_ID=$(az ad group show --group "$GROUP_NAME" --query id -o tsv 2>/dev/null || \
+  az ad group create --display-name "$GROUP_NAME" --mail-nickname "$GROUP_NAME" --query id -o tsv)
+az ad group member add --group "$GROUP_ID" --member-id "$DEPLOY_SP_OBJECT_ID" 2>/dev/null || true
+gh variable set SQL_AAD_ADMIN_GROUP_OBJECT_ID --body "$GROUP_ID"
+gh variable set SQL_AAD_ADMIN_GROUP_NAME --body "$GROUP_NAME"
+```
+
+- [ ] **Step 3: Document the prerequisite in `docs/deployment/README.md`**
+
+Add an "RSVP database (Azure SQL)" subsection covering: the AAD-only server, the `czw-sql-admins` group (must include the deploy SP so CI migrations authenticate), the required repo variables (`SQL_AAD_ADMIN_GROUP_OBJECT_ID`, `SQL_AAD_ADMIN_GROUP_NAME`, `ADMIN_EMAIL_ALLOWLIST`), and that `GOOGLE_CLIENT_ID`/`GOOGLE_CLIENT_SECRET` secrets stay empty until issue #63.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/bootstrap-azure.sh docs/deployment/README.md
+git commit -m "docs(infra): bootstrap the SQL admin Entra group + repo vars (#61)"
+```
+
+---
+
+### Task 8: Full verification gate
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Terraform fmt + validate (all)**
+
+Run:
+```bash
+cd infra/terraform
+terraform fmt -check -recursive
+terraform -chdir=environments/staging init -backend=false && terraform -chdir=environments/staging validate
+terraform -chdir=environments/production init -backend=false && terraform -chdir=environments/production validate
+```
+Expected: no fmt diff; `Success!` for both roots.
+
+- [ ] **Step 2: actionlint on changed workflows**
+
+Run: `actionlint`
+Expected: clean.
+
+- [ ] **Step 3: Repo gate**
+
+Run: `npm run lint && npm run build && npm run check:images`
+Expected: all pass (no app-code change).
+
+- [ ] **Step 4: Confirm no apply happened and the tree is clean**
+
+Run: `git status && git log --oneline origin/master..HEAD`
+Expected: clean tree; the Task 1–7 commits listed.
+
+---
+
+## Known risks (surface in the PR)
+
+- **`azuread_authentication_only` + omitted admin login:** some azurerm versions historically still required `administrator_login`/`password`. `validate` won't catch a runtime API requirement — first real `apply` (on merge) is the proof. If apply rejects it, add a dummy `administrator_login` with `azuread_authentication_only = true` still enforcing AAD-only.
+- **Global SQL server name uniqueness:** `sql-czw-<env>` must be globally unique; if `apply` fails on a name clash, add a `random_string` suffix in the `sql-database` module.
+- **Prereq ordering:** the `czw-sql-admins` group + repo vars (Task 7) must exist before the first `infra.yml` apply, or the plan fails on unset `TF_VAR_sql_admin_group_object_id`.

--- a/docs/superpowers/specs/2026-07-17-azure-sql-serverless-infra-design.md
+++ b/docs/superpowers/specs/2026-07-17-azure-sql-serverless-infra-design.md
@@ -132,13 +132,16 @@ Each migrate step:
 4. `npx prisma migrate deploy`.
 5. Remove the temporary firewall rule (always, even on failure).
 
-**Guarded on `prisma/schema.prisma` existence.** The deploy job checks out the
-repo, so until #62 adds the schema the guard (`if [ -f prisma/schema.prisma ]`)
-early-exits and CI stays green. When #62 lands it must add `actions/setup-node`
-(from `.nvmrc`) + `npm ci` to the deploy job and create
-`scripts/ensure-db-user.mjs` + the `db:migrate:deploy` npm script; the guard then
-passes and the grant + migrate run. `deploy.yml` currently ignores
-`infra/terraform/**` and `docs/**` path pushes; that is unchanged.
+**Guarded on `scripts/ensure-db-user.mjs` existence.** The deploy job checks out
+the repo and early-exits when that file is absent, so CI stays green. #62 landed
+the Prisma schema + local-dev tooling but **not** the deploy-migration path, so
+the guard's sentinel is deliberately the still-absent `ensure-db-user.mjs` rather
+than `prisma/schema.prisma` (which now exists). Activating the step is a distinct
+follow-up: create `scripts/ensure-db-user.mjs`, add a `db:migrate:deploy` npm
+script (`prisma migrate deploy`), add `actions/setup-node` + `npm ci` to the
+deploy job, and grant the deploy identity SQL firewall-rule write (bootstrap
+step 5). `deploy.yml` still ignores `infra/terraform/**` and `docs/**` pushes;
+that is unchanged.
 
 ### 5. Bootstrap / operational prerequisites (Owner-run, not CI — documented only)
 

--- a/docs/superpowers/specs/2026-07-17-azure-sql-serverless-infra-design.md
+++ b/docs/superpowers/specs/2026-07-17-azure-sql-serverless-infra-design.md
@@ -132,11 +132,13 @@ Each migrate step:
 4. `npx prisma migrate deploy`.
 5. Remove the temporary firewall rule (always, even on failure).
 
-**Guarded on `prisma/schema.prisma` existence.** Until #62 adds the schema, the
-job is a no-op (`if [ -f prisma/schema.prisma ]`), so CI stays green. The grant
-+ migrate activate automatically when #62 lands — no `deploy.yml` change needed
-then. `deploy.yml` currently ignores `infra/terraform/**` and `docs/**` path
-pushes; that is unchanged.
+**Guarded on `prisma/schema.prisma` existence.** The deploy job checks out the
+repo, so until #62 adds the schema the guard (`if [ -f prisma/schema.prisma ]`)
+early-exits and CI stays green. When #62 lands it must add `actions/setup-node`
+(from `.nvmrc`) + `npm ci` to the deploy job and create
+`scripts/ensure-db-user.mjs` + the `db:migrate:deploy` npm script; the guard then
+passes and the grant + migrate run. `deploy.yml` currently ignores
+`infra/terraform/**` and `docs/**` path pushes; that is unchanged.
 
 ### 5. Bootstrap / operational prerequisites (Owner-run, not CI — documented only)
 

--- a/docs/superpowers/specs/2026-07-17-azure-sql-serverless-infra-design.md
+++ b/docs/superpowers/specs/2026-07-17-azure-sql-serverless-infra-design.md
@@ -1,0 +1,188 @@
+# Azure SQL Serverless Database (Terraform) — Design
+
+**Date:** 2026-07-17
+**Issue:** #61 (RSVP epic #60, Wave 0 · foundation)
+**Status:** Approved (design); implementation not started
+**Depends on:** none · Blocks: #62 (Prisma data layer), #63 (Auth.js)
+
+## Summary
+
+Provision the RSVP datastore — an Azure SQL logical server plus one serverless
+database per environment (staging, production) — in Terraform alongside the
+existing stack, and wire the Container App to reach it **passwordlessly** via a
+managed identity. Also scaffold the Auth.js secret plumbing (so issue #63 is
+values-only) and add an (initially inert) `prisma migrate deploy` step to
+`deploy.yml`.
+
+No new compute: the database attaches to the existing Next.js Container App.
+
+## Locked decisions
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| DB auth | **Passwordless managed identity** (AAD-only server) | No secret to store/rotate. Verified supported: Prisma 7 `@prisma/adapter-mssql` handles `ActiveDirectoryManagedIdentity`; azurerm v4 supports `azuread_authentication_only`. |
+| Auth.js secrets | **Scaffold the plumbing** | TF generates `AUTH_SECRET`; OAuth secrets defined but empty until #63; admin allowlist as a repo variable. Makes #63 values-only. |
+| Production DB | **Warm** (auto-pause disabled) | Honors the existing "no guest-facing cold starts" production principle. Staging auto-pauses. Deliberately exceeds the "~$5/mo" acceptance line (flagged). |
+| Network | **Public endpoint + AAD-only + allow-Azure** | AAD-only means no login is usable without a valid Entra token, so a public endpoint is not anonymously reachable. A private endpoint would require recreating the (non-VNet-injected) Container App Environment — out of scope. |
+
+### Why passwordless MI is viable here (grounding)
+
+The RSVP high-level design flagged MI as "preferred, with a Key Vault
+connection-string fallback if Prisma's Azure AD token path proves fiddly."
+Verified against current versions, the token path is **not** the rough edge it
+once was:
+
+- **Prisma 7 `@prisma/adapter-mssql`** supports Entra ID auth as a first-class
+  option — `authentication: { type: 'azure-active-directory-default' }`, or
+  `authentication=ActiveDirectoryManagedIdentity` (optional `clientId`) in the
+  connection string. Token acquisition/refresh is handled by the
+  `mssql`/`tedious` + `@azure/identity` stack, not hand-rolled.
+- **azurerm v4** supports `azuread_administrator { azuread_authentication_only =
+  true }`, so the server can be provisioned AAD-only with no SQL admin password.
+
+The two real (non-Prisma) frictions that remain, and how this design handles
+them:
+
+1. **The DB-side grant Terraform can't express.** The app identity must be added
+   *inside* the database (`CREATE USER ... FROM EXTERNAL PROVIDER` + role grant);
+   there is no native `azurerm` resource for a contained DB user. → Handled by an
+   idempotent T-SQL step in the CI migrate job (run as the AAD admin).
+2. **CI must reach the DB through the firewall to migrate.** A GitHub-hosted
+   runner is not an Azure service, so "allow Azure services" does not cover it.
+   → The migrate job adds the runner's egress IP to the firewall for the run and
+   removes it after, authenticating passwordlessly via the OIDC token the
+   workflow already uses.
+
+## Architecture
+
+Everything attaches to the existing per-environment `env-stack`. Apply order is
+unchanged (`shared → staging → production`); the shared stack is untouched.
+
+### 1. New module: `infra/terraform/modules/sql-database/`
+
+Reusable, instantiated once per environment by `env-stack`.
+
+- **`azurerm_mssql_server`**
+  - `azuread_administrator` block: `azuread_authentication_only = true`,
+    `login_username` = admin group display name, `object_id` = admin group
+    object id (variable), `tenant_id`.
+  - No `administrator_login` / `administrator_login_password`.
+  - `public_network_access_enabled = true`.
+- **`azurerm_mssql_database`**
+  - SKU `GP_S_Gen5_1` (serverless, Gen5, 1 vCore max), `min_capacity = 0.5`.
+  - `max_size_gb = 2`.
+  - `storage_account_type = "Local"` (LRS backup — cheaper; geo-redundancy not
+    needed for a recoverable, re-seedable guest list).
+  - `auto_pause_delay_in_minutes`: **60** (staging) / **-1** = disabled
+    (production), passed as a variable.
+- **`azurerm_mssql_firewall_rule "allow_azure_services"`** — start/end
+  `0.0.0.0` (the ACA outbound reaches the DB from within Azure).
+- **Outputs:** `server_fqdn`, `database_name`.
+
+**Server name is globally unique.** Use `sql-czw-${environment}`. If a name is
+already taken at apply time, fall back to a short `random_string` suffix
+(documented in the module README/variable description). Database name: `rsvp`
+(the server differs per env, so the DB name need not).
+
+### 2. App identity + `container-app` module changes (additive, backward-compatible)
+
+- New per-env **user-assigned identity `id-czw-app-${environment}`** (created in
+  `env-stack`), attached to the Container App **alongside** the existing
+  `acr_pull` identity.
+- `container-app` module gains three optional inputs, all defaulting to
+  empty/no-op so existing behavior is unchanged:
+  - `additional_identity_ids : list(string)` — merged into the `identity` block.
+  - `extra_env : list(object({ name, value }))` — appended to the container `env`.
+  - `secrets : list(object({ name, value }))` + `secret_env : list(object({ name,
+    secret_name }))` — ACA `secret` blocks and their `env { secret_ref }` wiring.
+- The `registry.identity` and `acr_pull` wiring is untouched.
+
+### 3. Env-var contract consumed by #62 / #63 (documented, set here)
+
+Wired onto the Container App now so downstream issues are values-only:
+
+- `DATABASE_URL` (non-secret) — app connection string, e.g.
+  `sqlserver://sql-czw-staging.database.windows.net:1433;database=rsvp;authentication=ActiveDirectoryManagedIdentity;clientId=<app-uami-client-id>;encrypt=true`.
+- `AUTH_SECRET` (secret) — generated by `random_password`, ACA secret
+  `auth-secret`.
+- `AUTH_GOOGLE_ID` / `AUTH_GOOGLE_SECRET` (secrets) — ACA secrets
+  `google-client-id` / `google-client-secret`, **empty** until #63 supplies real
+  values via CI.
+
+CI migrations use their **own** connection string with
+`authentication=DefaultAzureCredential` (the runner authenticated as the AAD
+admin), never the app's MI clientId.
+
+### 4. `deploy.yml` migrate job (inert until #62)
+
+A migrate step runs before each environment's deploy, preserving the
+build-once / promote-same-digest flow:
+
+```
+build → migrate+deploy staging → smoke → (approval) → migrate+deploy production → smoke
+```
+
+Each migrate step:
+
+1. `azure/login` via existing OIDC (deploy service principal).
+2. Add the runner's current egress IP as a temporary SQL firewall rule.
+3. Idempotently ensure the app DB user (run as AAD admin):
+   `IF NOT EXISTS (...) CREATE USER [id-czw-app-<env>] FROM EXTERNAL PROVIDER;`
+   then add it to `db_datareader`, `db_datawriter`, `db_ddladmin`.
+4. `npx prisma migrate deploy`.
+5. Remove the temporary firewall rule (always, even on failure).
+
+**Guarded on `prisma/schema.prisma` existence.** Until #62 adds the schema, the
+job is a no-op (`if [ -f prisma/schema.prisma ]`), so CI stays green. The grant
++ migrate activate automatically when #62 lands — no `deploy.yml` change needed
+then. `deploy.yml` currently ignores `infra/terraform/**` and `docs/**` path
+pushes; that is unchanged.
+
+### 5. Bootstrap / operational prerequisites (Owner-run, not CI — documented only)
+
+The CI deploy identity is RG-scoped Contributor and **cannot** create Entra
+directory objects. So, out-of-band (in `scripts/bootstrap-azure.sh` +
+`docs/deployment/README.md`):
+
+- Create an Entra **group `czw-sql-admins`** and add (a) the human admin(s) and
+  (b) the **CI deploy service principal** (so CI can run the grant + migrations
+  as the AAD admin).
+- Expose the group's **object id** and display name as GitHub repo variables
+  (e.g. `SQL_AAD_ADMIN_GROUP_OBJECT_ID`, `SQL_AAD_ADMIN_GROUP_NAME`); tenant id
+  already exists as `AZURE_TENANT_ID`.
+- Add `ADMIN_EMAIL_ALLOWLIST` as a GitHub repo variable (consumed by #63).
+
+Setting the AAD admin by **object id** needs no Graph permission for the CI
+identity — it is an ARM write on the SQL server, which RG Contributor already
+grants.
+
+## Cost
+
+| Environment | Idle behavior | Approx. idle cost |
+|---|---|---|
+| Staging | Auto-pauses after 60 min | ~$5/mo (storage floor; compute $0 while paused) |
+| Production | Warm (auto-pause disabled), min 0.5 vCore | ~$15–30/mo |
+
+Production deliberately exceeds the issue's "~$5/mo idle floor" acceptance line —
+a conscious trade for zero guest-facing DB resume latency, consistent with the
+existing production `min_replicas = 1` warm-replica policy. Flagged in the PR.
+
+## Scope boundaries
+
+**In scope:** SQL server + serverless DB per env, firewall, app MI + DB-user
+grant (via CI job), Auth.js secret scaffold, admin-allowlist repo variable,
+guarded migrate step, bootstrap/docs updates.
+
+**Out of scope (owned by later issues):** Prisma schema/migrations/seed (#62),
+Auth.js app code + real OAuth apps (#63), private-endpoint networking, Key Vault.
+
+## Verification
+
+- `terraform fmt -check -recursive infra/terraform` clean.
+- Per-env `terraform -chdir=infra/terraform/environments/<env> init -backend=false
+  && terraform validate` green (staging + production).
+- `actionlint` clean on the `deploy.yml` change.
+- `npm run lint && npm run build && npm run check:images` green (no app-code
+  change, but the repo gate must pass).
+- No live `apply` from the PR; `infra.yml` applies on merge to `master`
+  (`shared`/`production` gated by approval).

--- a/docs/superpowers/specs/2026-07-17-azure-sql-serverless-infra-design.md
+++ b/docs/superpowers/specs/2026-07-17-azure-sql-serverless-infra-design.md
@@ -132,16 +132,17 @@ Each migrate step:
 4. `npx prisma migrate deploy`.
 5. Remove the temporary firewall rule (always, even on failure).
 
-**Guarded on `scripts/ensure-db-user.mjs` existence.** The deploy job checks out
-the repo and early-exits when that file is absent, so CI stays green. #62 landed
-the Prisma schema + local-dev tooling but **not** the deploy-migration path, so
-the guard's sentinel is deliberately the still-absent `ensure-db-user.mjs` rather
-than `prisma/schema.prisma` (which now exists). Activating the step is a distinct
-follow-up: create `scripts/ensure-db-user.mjs`, add a `db:migrate:deploy` npm
-script (`prisma migrate deploy`), add `actions/setup-node` + `npm ci` to the
-deploy job, and grant the deploy identity SQL firewall-rule write (bootstrap
-step 5). `deploy.yml` still ignores `infra/terraform/**` and `docs/**` pushes;
-that is unchanged.
+**Gated on the `ENABLE_DB_MIGRATIONS` repo variable** (off by default). The full
+path is wired in this issue — `actions/checkout` + `setup-node` (from `.nvmrc`) +
+`npm ci`, then `scripts/ensure-db-user.mjs` (idempotent `CREATE USER ... FROM
+EXTERNAL PROVIDER` granting the app identity `db_datareader`/`db_datawriter` only;
+migrations run as the admin, so the app never needs DDL) followed by
+`db:migrate:deploy`. The flag decouples "code present and reviewed" from "runs
+against a live DB," so the first post-merge deploy can't race the first Terraform
+apply: turn it on once, after the SQL server exists and the deploy identity has
+`SQL Server Contributor` + `czw-sql-admins` membership (both set by
+`bootstrap-azure.sh`). `deploy.yml` still ignores `infra/terraform/**` and
+`docs/**` pushes; that is unchanged.
 
 ### 5. Bootstrap / operational prerequisites (Owner-run, not CI — documented only)
 

--- a/infra/terraform/environments/production/.terraform.lock.hcl
+++ b/infra/terraform/environments/production/.terraform.lock.hcl
@@ -39,3 +39,25 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:ea3be732d424c36634dd105425879ea7610224cada0c59ed6172ce67b610289d",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/terraform/environments/production/main.tf
+++ b/infra/terraform/environments/production/main.tf
@@ -29,4 +29,11 @@ module "stack" {
   monthly_budget_amount      = var.monthly_budget_amount
   budget_start_date          = var.budget_start_date
   tags                       = var.tags
+
+  sql_admin_group_name           = var.sql_admin_group_name
+  sql_admin_group_object_id      = var.sql_admin_group_object_id
+  tenant_id                      = var.tenant_id
+  db_auto_pause_delay_in_minutes = -1
+  google_client_id               = var.google_client_id
+  google_client_secret           = var.google_client_secret
 }

--- a/infra/terraform/environments/production/variables.tf
+++ b/infra/terraform/environments/production/variables.tf
@@ -62,3 +62,31 @@ variable "custom_domains" {
   description = "Public hostnames bound to the production app (behind the Cloudflare proxy)."
   default     = ["czarnickwedding.com", "www.czarnickwedding.com"]
 }
+
+variable "sql_admin_group_name" {
+  type        = string
+  description = "Display name of the Entra group set as the SQL server AAD admin."
+}
+
+variable "sql_admin_group_object_id" {
+  type        = string
+  description = "Object ID of the SQL admin Entra group."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Entra tenant ID."
+}
+
+variable "google_client_id" {
+  type        = string
+  description = "Google OAuth client ID for Auth.js. Empty until issue #63."
+  default     = ""
+}
+
+variable "google_client_secret" {
+  type        = string
+  description = "Google OAuth client secret for Auth.js. Empty until issue #63."
+  default     = ""
+  sensitive   = true
+}

--- a/infra/terraform/environments/staging/.terraform.lock.hcl
+++ b/infra/terraform/environments/staging/.terraform.lock.hcl
@@ -39,3 +39,25 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:ea3be732d424c36634dd105425879ea7610224cada0c59ed6172ce67b610289d",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.6"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "h1:UlBuNVuCGJ39tTv2c5gz2NRZnQbXfbIWbTzWcth5o74=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/terraform/environments/staging/main.tf
+++ b/infra/terraform/environments/staging/main.tf
@@ -29,4 +29,11 @@ module "stack" {
   monthly_budget_amount      = var.monthly_budget_amount
   budget_start_date          = var.budget_start_date
   tags                       = var.tags
+
+  sql_admin_group_name           = var.sql_admin_group_name
+  sql_admin_group_object_id      = var.sql_admin_group_object_id
+  tenant_id                      = var.tenant_id
+  db_auto_pause_delay_in_minutes = 60
+  google_client_id               = var.google_client_id
+  google_client_secret           = var.google_client_secret
 }

--- a/infra/terraform/environments/staging/variables.tf
+++ b/infra/terraform/environments/staging/variables.tf
@@ -62,3 +62,31 @@ variable "custom_domains" {
   description = "Public hostnames bound to the staging app (behind the Cloudflare proxy)."
   default     = ["staging.czarnickwedding.com"]
 }
+
+variable "sql_admin_group_name" {
+  type        = string
+  description = "Display name of the Entra group set as the SQL server AAD admin."
+}
+
+variable "sql_admin_group_object_id" {
+  type        = string
+  description = "Object ID of the SQL admin Entra group."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Entra tenant ID."
+}
+
+variable "google_client_id" {
+  type        = string
+  description = "Google OAuth client ID for Auth.js. Empty until issue #63."
+  default     = ""
+}
+
+variable "google_client_secret" {
+  type        = string
+  description = "Google OAuth client secret for Auth.js. Empty until issue #63."
+  default     = ""
+  sensitive   = true
+}

--- a/infra/terraform/modules/container-app/main.tf
+++ b/infra/terraform/modules/container-app/main.tf
@@ -7,12 +7,20 @@ resource "azurerm_container_app" "this" {
 
   identity {
     type         = "UserAssigned"
-    identity_ids = [var.acr_pull_identity_id]
+    identity_ids = concat([var.acr_pull_identity_id], var.additional_identity_ids)
   }
 
   registry {
     server   = var.acr_login_server
     identity = var.acr_pull_identity_id
+  }
+
+  dynamic "secret" {
+    for_each = { for s in var.secrets : s.name => s.value }
+    content {
+      name  = secret.key
+      value = secret.value
+    }
   }
 
   ingress {
@@ -51,6 +59,22 @@ resource "azurerm_container_app" "this" {
       env {
         name  = "NODE_ENV"
         value = "production"
+      }
+
+      dynamic "env" {
+        for_each = { for e in var.extra_env : e.name => e.value }
+        content {
+          name  = env.key
+          value = env.value
+        }
+      }
+
+      dynamic "env" {
+        for_each = { for e in var.secret_env : e.name => e.secret_name }
+        content {
+          name        = env.key
+          secret_name = env.value
+        }
       }
 
       startup_probe {

--- a/infra/terraform/modules/container-app/variables.tf
+++ b/infra/terraform/modules/container-app/variables.tf
@@ -79,3 +79,36 @@ variable "tags" {
   description = "Resource tags."
   default     = {}
 }
+
+variable "additional_identity_ids" {
+  type        = list(string)
+  description = "Extra user-assigned identity IDs to attach (e.g. the app's DB identity), merged with the AcrPull identity."
+  default     = []
+}
+
+variable "extra_env" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "Plain (non-secret) environment variables appended to the container."
+  default     = []
+}
+
+variable "secrets" {
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  description = "Container App secrets. Empty-valued entries must be filtered out by the caller (ACA rejects empty secret values)."
+  default     = []
+}
+
+variable "secret_env" {
+  type = list(object({
+    name        = string
+    secret_name = string
+  }))
+  description = "Environment variables that reference a secret by name (secret_ref)."
+  default     = []
+}

--- a/infra/terraform/modules/env-stack/main.tf
+++ b/infra/terraform/modules/env-stack/main.tf
@@ -31,7 +31,57 @@ module "app" {
   min_replicas                 = var.min_replicas
   max_replicas                 = var.max_replicas
   allowed_ip_ranges            = var.allowed_ip_ranges
+  additional_identity_ids      = [azurerm_user_assigned_identity.app.id]
+  extra_env                    = [{ name = "DATABASE_URL", value = local.database_url }]
+  secrets                      = local.app_secrets
+  secret_env                   = local.app_secret_env
   tags                         = var.tags
+}
+
+# Per-env identity the app uses for passwordless (managed identity) DB access.
+# Granted inside the database (CREATE USER ... FROM EXTERNAL PROVIDER) by the CI
+# migrate job, not by Terraform (no azurerm resource for contained DB users).
+resource "azurerm_user_assigned_identity" "app" {
+  name                = "id-czw-app-${var.environment}"
+  location            = data.azurerm_resource_group.env.location
+  resource_group_name = data.azurerm_resource_group.env.name
+  tags                = var.tags
+}
+
+module "database" {
+  source = "../sql-database"
+
+  environment                 = var.environment
+  location                    = data.azurerm_resource_group.env.location
+  resource_group_name         = data.azurerm_resource_group.env.name
+  aad_admin_login             = var.sql_admin_group_name
+  aad_admin_object_id         = var.sql_admin_group_object_id
+  tenant_id                   = var.tenant_id
+  auto_pause_delay_in_minutes = var.db_auto_pause_delay_in_minutes
+  tags                        = var.tags
+}
+
+# Auth.js session secret — generated, never hand-managed. Base64 of 32 bytes.
+resource "random_id" "auth_secret" {
+  byte_length = 32
+}
+
+locals {
+  database_url = "sqlserver://${module.database.server_fqdn}:1433;database=${module.database.database_name};authentication=ActiveDirectoryManagedIdentity;clientId=${azurerm_user_assigned_identity.app.client_id};encrypt=true"
+
+  # ACA rejects empty secret values, so OAuth secrets appear only once #63
+  # supplies real values. AUTH_SECRET is always present (generated).
+  app_secrets = concat(
+    [{ name = "auth-secret", value = random_id.auth_secret.b64_std }],
+    var.google_client_id == "" ? [] : [{ name = "google-client-id", value = var.google_client_id }],
+    var.google_client_secret == "" ? [] : [{ name = "google-client-secret", value = var.google_client_secret }],
+  )
+
+  app_secret_env = concat(
+    [{ name = "AUTH_SECRET", secret_name = "auth-secret" }],
+    var.google_client_id == "" ? [] : [{ name = "AUTH_GOOGLE_ID", secret_name = "google-client-id" }],
+    var.google_client_secret == "" ? [] : [{ name = "AUTH_GOOGLE_SECRET", secret_name = "google-client-secret" }],
+  )
 }
 
 resource "azurerm_consumption_budget_resource_group" "env" {

--- a/infra/terraform/modules/env-stack/outputs.tf
+++ b/infra/terraform/modules/env-stack/outputs.tf
@@ -7,3 +7,8 @@ output "default_fqdn" {
   value       = module.app.default_fqdn
   description = "Default ingress FQDN (used for smoke tests, bypassing Cloudflare)."
 }
+
+output "sql_server_fqdn" {
+  value       = module.database.server_fqdn
+  description = "SQL server FQDN for the environment."
+}

--- a/infra/terraform/modules/env-stack/variables.tf
+++ b/infra/terraform/modules/env-stack/variables.tf
@@ -90,3 +90,36 @@ variable "origin_private_key_pem" {
   description = "Origin CA private key (PEM), from the shared stack."
   sensitive   = true
 }
+
+variable "sql_admin_group_name" {
+  type        = string
+  description = "Display name of the Entra group set as the SQL server AAD admin (contains human admins + the CI deploy SP)."
+}
+
+variable "sql_admin_group_object_id" {
+  type        = string
+  description = "Object ID of the SQL admin Entra group."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Entra tenant ID."
+}
+
+variable "db_auto_pause_delay_in_minutes" {
+  type        = number
+  description = "Serverless auto-pause delay. 60 for staging (pause when idle); -1 for production (stay warm)."
+}
+
+variable "google_client_id" {
+  type        = string
+  description = "Google OAuth client ID for Auth.js. Empty until issue #63 supplies it."
+  default     = ""
+}
+
+variable "google_client_secret" {
+  type        = string
+  description = "Google OAuth client secret for Auth.js. Empty until issue #63 supplies it."
+  default     = ""
+  sensitive   = true
+}

--- a/infra/terraform/modules/env-stack/versions.tf
+++ b/infra/terraform/modules/env-stack/versions.tf
@@ -8,5 +8,9 @@ terraform {
       source  = "cloudflare/cloudflare"
       version = "~> 5.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.6"
+    }
   }
 }

--- a/infra/terraform/modules/sql-database/main.tf
+++ b/infra/terraform/modules/sql-database/main.tf
@@ -1,0 +1,44 @@
+# AAD-only server: no SQL login/password exists, so a public endpoint is not
+# anonymously usable — every connection needs a valid Entra token from an
+# authorized principal.
+resource "azurerm_mssql_server" "this" {
+  name                          = "sql-czw-${var.environment}"
+  resource_group_name           = var.resource_group_name
+  location                      = var.location
+  version                       = "12.0"
+  minimum_tls_version           = "1.2"
+  public_network_access_enabled = true
+
+  azuread_administrator {
+    login_username              = var.aad_admin_login
+    object_id                   = var.aad_admin_object_id
+    tenant_id                   = var.tenant_id
+    azuread_authentication_only = true
+  }
+
+  tags = var.tags
+}
+
+# Serverless General Purpose. min_capacity 0.5 vCore floor; storage LRS (Local)
+# since the guest list is re-seedable and does not need geo-redundant backups.
+resource "azurerm_mssql_database" "rsvp" {
+  name                        = "rsvp"
+  server_id                   = azurerm_mssql_server.this.id
+  sku_name                    = "GP_S_Gen5_1"
+  min_capacity                = 0.5
+  max_size_gb                 = 2
+  auto_pause_delay_in_minutes = var.auto_pause_delay_in_minutes
+  storage_account_type        = "Local"
+
+  tags = var.tags
+}
+
+# Lets the Container App (Azure outbound) reach the server. The 0.0.0.0 rule is
+# Azure's "Allow all Azure services" convention. Non-Azure clients (e.g. the CI
+# runner) add their own IP transiently in the migrate job.
+resource "azurerm_mssql_firewall_rule" "allow_azure_services" {
+  name             = "AllowAllAzureServices"
+  server_id        = azurerm_mssql_server.this.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}

--- a/infra/terraform/modules/sql-database/outputs.tf
+++ b/infra/terraform/modules/sql-database/outputs.tf
@@ -1,0 +1,9 @@
+output "server_fqdn" {
+  value       = azurerm_mssql_server.this.fully_qualified_domain_name
+  description = "SQL server FQDN, used to build the app connection string."
+}
+
+output "database_name" {
+  value       = azurerm_mssql_database.rsvp.name
+  description = "Database name (rsvp)."
+}

--- a/infra/terraform/modules/sql-database/variables.tf
+++ b/infra/terraform/modules/sql-database/variables.tf
@@ -1,0 +1,40 @@
+variable "environment" {
+  type        = string
+  description = "Environment name (staging|production). Used in resource names."
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region for the SQL server and database."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group that hosts the SQL server."
+}
+
+variable "aad_admin_login" {
+  type        = string
+  description = "Display name of the Entra principal set as the server's AAD admin (e.g. the czw-sql-admins group)."
+}
+
+variable "aad_admin_object_id" {
+  type        = string
+  description = "Object ID of the Entra admin principal. Set by object ID so an RG-Contributor CI identity needs no Graph permission."
+}
+
+variable "tenant_id" {
+  type        = string
+  description = "Entra tenant ID for the AAD administrator."
+}
+
+variable "auto_pause_delay_in_minutes" {
+  type        = number
+  description = "Serverless auto-pause idle delay. 60 = pause after 1h idle; -1 = never pause (warm)."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Resource tags."
+  default     = {}
+}

--- a/infra/terraform/modules/sql-database/versions.tf
+++ b/infra/terraform/modules/sql-database/versions.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:up": "docker compose -f docker-compose.dev.yml up -d",
     "db:down": "docker compose -f docker-compose.dev.yml down",
     "db:migrate": "prisma migrate dev",
+    "db:migrate:deploy": "prisma migrate deploy",
     "db:seed": "prisma db seed",
     "db:reset": "prisma migrate reset --force",
     "db:studio": "prisma studio"

--- a/scripts/bootstrap-azure.sh
+++ b/scripts/bootstrap-azure.sh
@@ -192,6 +192,15 @@ done
 RG_SHARED_ID=$(az group show -n "$RG_SHARED" --query id -o tsv)
 assign "$DEPLOY_PRINCIPAL_ID" "AcrPush" "$RG_SHARED_ID"
 
+# CI migrations open a transient firewall rule for the runner IP on the env's SQL
+# server (GitHub runners aren't "Azure services"), so the deploy identity needs
+# SQL server management in the app RGs. Scoped to the two app RGs; only exercised
+# once ENABLE_DB_MIGRATIONS=true, but harmless to grant ahead of the first apply.
+for rg in "$RG_STAGING" "$RG_PRODUCTION"; do
+  RG_ID=$(az group show -n "$rg" --query id -o tsv)
+  assign "$DEPLOY_PRINCIPAL_ID" "SQL Server Contributor" "$RG_ID"
+done
+
 # Note: per-resource-group budgets (with email alerts) are created by Terraform.
 # A subscription-level budget can be added in the portal if desired, but the
 # Free Trial spending limit — not budgets — is the real hard cap on spend.
@@ -200,10 +209,10 @@ echo "==> SQL admin Entra group (AAD-only DB auth)"
 # The RSVP database is AAD-only — no SQL logins exist. Terraform sets this group
 # as the server's Entra admin (by object id, so the RG-Contributor infra identity
 # needs no directory permission). Group members can sign in to the DB as admin;
-# the deploy identity is a member so CI migrations (issue #62) authenticate
-# passwordlessly via its OIDC token. Creating an Entra group needs a directory
-# role (e.g. Groups Administrator) — if this errors, create the group by hand and
-# set the two repo variables below manually.
+# the deploy identity is a member so CI migrations authenticate passwordlessly via
+# its OIDC token. Creating an Entra group needs a directory role (e.g. Groups
+# Administrator) — if this errors, create the group by hand and set the two repo
+# variables below manually.
 SQL_ADMIN_GROUP="czw-sql-admins"
 SQL_ADMIN_GROUP_OID=$(az ad group show --group "$SQL_ADMIN_GROUP" --query id -o tsv 2>/dev/null \
   || az ad group create --display-name "$SQL_ADMIN_GROUP" --mail-nickname "$SQL_ADMIN_GROUP" --query id -o tsv)
@@ -261,11 +270,10 @@ MANUAL steps still required (see docs/deployment/README.md):
        az acr config authentication-as-arm update -n $ACR_NAME --status enabled
   4. Set 'acr_name' in infra/terraform/environments/shared to: $ACR_NAME
      (or rely on the TF_VAR_acr_name repo variable — already set).
-  5. Before enabling RSVP DB migrations (issue #62), grant the deploy identity
-     ($DEPLOY_CLIENT_ID) SQL firewall-rule write on the staging + production SQL
-     servers so the migrate job can open/close its runner IP, e.g.:
-       az role assignment create --assignee "$DEPLOY_CLIENT_ID" \\
-         --role "SQL Server Contributor" -g rg-czw-staging
-     (repeat for rg-czw-production). Not needed until migrations go live.
+  5. RSVP DB migrations in deploy.yml are OFF until you opt in. After the first
+     'staging' Terraform apply creates the SQL server, turn them on with:
+       gh variable set ENABLE_DB_MIGRATIONS --body true
+     (the deploy identity's SQL role + czw-sql-admins membership are already set
+     above). Set it back to any other value to disable again.
 =================================================================
 EOF

--- a/scripts/bootstrap-azure.sh
+++ b/scripts/bootstrap-azure.sh
@@ -196,6 +196,23 @@ assign "$DEPLOY_PRINCIPAL_ID" "AcrPush" "$RG_SHARED_ID"
 # A subscription-level budget can be added in the portal if desired, but the
 # Free Trial spending limit — not budgets — is the real hard cap on spend.
 
+echo "==> SQL admin Entra group (AAD-only DB auth)"
+# The RSVP database is AAD-only — no SQL logins exist. Terraform sets this group
+# as the server's Entra admin (by object id, so the RG-Contributor infra identity
+# needs no directory permission). Group members can sign in to the DB as admin;
+# the deploy identity is a member so CI migrations (issue #62) authenticate
+# passwordlessly via its OIDC token. Creating an Entra group needs a directory
+# role (e.g. Groups Administrator) — if this errors, create the group by hand and
+# set the two repo variables below manually.
+SQL_ADMIN_GROUP="czw-sql-admins"
+SQL_ADMIN_GROUP_OID=$(az ad group show --group "$SQL_ADMIN_GROUP" --query id -o tsv 2>/dev/null \
+  || az ad group create --display-name "$SQL_ADMIN_GROUP" --mail-nickname "$SQL_ADMIN_GROUP" --query id -o tsv)
+grp_member() { # member-object-id
+  az ad group member add --group "$SQL_ADMIN_GROUP_OID" --member-id "$1" --only-show-errors -o none 2>/dev/null || true
+}
+grp_member "$CURRENT_USER_OID"
+grp_member "$DEPLOY_PRINCIPAL_ID"
+
 echo "==> GitHub repository variables"
 gh_var() { gh variable set "$1" -R "$GITHUB_REPO" -b "$2"; }
 gh_var AZURE_TENANT_ID       "$TENANT_ID"
@@ -205,6 +222,8 @@ gh_var AZURE_DEPLOY_CLIENT_ID "$DEPLOY_CLIENT_ID"
 gh_var TFSTATE_STORAGE_ACCOUNT "$TFSTATE_SA"
 gh_var ACR_NAME              "$ACR_NAME"
 gh_var BUDGET_START_DATE     "$BUDGET_START_DATE"
+gh_var SQL_AAD_ADMIN_GROUP_OBJECT_ID "$SQL_ADMIN_GROUP_OID"
+gh_var SQL_AAD_ADMIN_GROUP_NAME      "$SQL_ADMIN_GROUP"
 # Alert email is PII -> a masked secret, not a variable. Remove any prior variable.
 gh variable delete ALERT_EMAILS_JSON -R "$GITHUB_REPO" 2>/dev/null || true
 gh secret set ALERT_EMAILS_JSON -R "$GITHUB_REPO" -b "[\"${ALERT_EMAIL}\"]"
@@ -228,6 +247,8 @@ Bootstrap complete. Recorded to GitHub repo variables:
   AZURE_DEPLOY_CLIENT_ID = $DEPLOY_CLIENT_ID
   TFSTATE_STORAGE_ACCOUNT= $TFSTATE_SA
   ACR_NAME               = $ACR_NAME
+  SQL_AAD_ADMIN_GROUP_OBJECT_ID = $SQL_ADMIN_GROUP_OID
+  SQL_AAD_ADMIN_GROUP_NAME      = $SQL_ADMIN_GROUP
 
 MANUAL steps still required (see docs/deployment/README.md):
   1. In GitHub: add yourself as a required reviewer on the 'infra' and
@@ -240,5 +261,11 @@ MANUAL steps still required (see docs/deployment/README.md):
        az acr config authentication-as-arm update -n $ACR_NAME --status enabled
   4. Set 'acr_name' in infra/terraform/environments/shared to: $ACR_NAME
      (or rely on the TF_VAR_acr_name repo variable — already set).
+  5. Before enabling RSVP DB migrations (issue #62), grant the deploy identity
+     ($DEPLOY_CLIENT_ID) SQL firewall-rule write on the staging + production SQL
+     servers so the migrate job can open/close its runner IP, e.g.:
+       az role assignment create --assignee "$DEPLOY_CLIENT_ID" \\
+         --role "SQL Server Contributor" -g rg-czw-staging
+     (repeat for rg-czw-production). Not needed until migrations go live.
 =================================================================
 EOF

--- a/scripts/ensure-db-user.mjs
+++ b/scripts/ensure-db-user.mjs
@@ -1,0 +1,58 @@
+// Idempotently grant the app's managed identity access to the RSVP database.
+//
+// Azure SQL has no Terraform resource for a contained database user, so this runs
+// once per deploy from CI (as the AAD admin) to ensure the app identity exists as
+// a DB user with least-privilege data access. Migrations run separately as the
+// admin, so the app identity never needs DDL rights.
+//
+// Auth is passwordless: `mssql`'s azure-active-directory-default mode resolves the
+// runner's `az login` session (AzureCliCredential) to a database.windows.net token.
+//
+// Usage: node scripts/ensure-db-user.mjs <app-identity-name>
+//   env: SQL_SERVER (FQDN), SQL_DATABASE
+
+import sql from 'mssql';
+
+const identityName = process.argv[2];
+const server = process.env.SQL_SERVER;
+const database = process.env.SQL_DATABASE;
+
+if (!identityName || !server || !database) {
+  console.error('Usage: node scripts/ensure-db-user.mjs <app-identity-name> (env: SQL_SERVER, SQL_DATABASE)');
+  process.exit(1);
+}
+
+// The name is interpolated into DDL, so constrain it to the managed-identity
+// naming charset before it ever reaches the server.
+if (!/^[A-Za-z0-9-]+$/.test(identityName)) {
+  console.error(`Refusing unsafe identity name: ${identityName}`);
+  process.exit(1);
+}
+
+const grantSql = `
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = '${identityName}')
+  CREATE USER [${identityName}] FROM EXTERNAL PROVIDER;
+
+IF IS_ROLEMEMBER('db_datareader', '${identityName}') = 0
+  ALTER ROLE db_datareader ADD MEMBER [${identityName}];
+
+IF IS_ROLEMEMBER('db_datawriter', '${identityName}') = 0
+  ALTER ROLE db_datawriter ADD MEMBER [${identityName}];
+`;
+
+let pool;
+try {
+  pool = await sql.connect({
+    server,
+    database,
+    authentication: { type: 'azure-active-directory-default' },
+    options: { encrypt: true },
+  });
+  await pool.request().batch(grantSql);
+  console.log(`Ensured DB user [${identityName}] with db_datareader + db_datawriter on ${database}.`);
+} catch (error) {
+  console.error(`Failed to ensure DB user [${identityName}]: ${error.message}`);
+  process.exit(1);
+} finally {
+  await pool?.close();
+}


### PR DESCRIPTION
Closes #61

## Plan

Provision the RSVP datastore in Terraform: an Azure SQL logical server + one
serverless database (`rsvp`) per environment, reachable **passwordlessly** from
the Container App via a per-env managed identity (AAD-only server, no SQL
password anywhere). Also scaffolds the Auth.js secret plumbing (so #63 is
values-only) and adds an inert-until-#62 `prisma migrate deploy` step.

Design & plan: `docs/superpowers/specs/2026-07-17-azure-sql-serverless-infra-design.md`,
`docs/superpowers/plans/2026-07-17-azure-sql-serverless-infra.md`.

**Decisions grilled at brainstorm** (verified against current versions —
Prisma 7 `@prisma/adapter-mssql` supports `ActiveDirectoryManagedIdentity`;
azurerm v4 supports `azuread_authentication_only`):

- **DB auth:** passwordless managed identity, AAD-only server.
- **Auth.js secrets:** scaffold the plumbing (generated `AUTH_SECRET`; empty
  OAuth secrets until #63; admin allowlist as a repo variable).
- **Prod DB:** warm (auto-pause disabled); staging auto-pauses. See cost note.
- **Network:** public endpoint + AAD-only + allow-Azure (no VNet/CAE recreation).

## What's here

- New `sql-database` module (server, serverless `GP_S_Gen5_1` DB, allow-Azure
  firewall) instantiated per-env by `env-stack`.
- `container-app` module extended (additive) with extra identities / env / secrets.
- App identity `id-czw-app-<env>` + `DATABASE_URL` (MI) + `AUTH_SECRET` wired.
- staging (auto-pause 60) / production (warm, -1) roots pass the new vars; CI
  feeds them via `_terraform-env.yml`.
- **CI migrations fully wired** in `_deploy-env.yml` (delivers #61's "add prisma
  migrate deploy step" charter): `scripts/ensure-db-user.mjs` grants the app
  identity least-privilege read/write, `db:migrate:deploy` applies migrations,
  gated behind the `ENABLE_DB_MIGRATIONS` repo variable (off by default).
- `bootstrap-azure.sh` + deployment README: the `czw-sql-admins` Entra group +
  repo variables.

## Rebased onto master after #62 merged

Clean rebase — **no file overlap with #62, nothing duplicated** (#62 added the
Prisma schema/seed/local-dev tooling; this PR is Terraform + CI only). One
integration fix: #62 landed `prisma/schema.prisma` but not the deploy-migration
path, so this PR now **completes that path itself** (it's #61's charter — no other
issue owns it) rather than leaving a half-wired step that would break deploys.

## Verification

- `terraform fmt -check -recursive` clean; `validate` green for staging + production.
- `actionlint` clean; `npm run lint && build && check:images` all pass; `shellcheck` clean.
- **`db:migrate:deploy` verified end-to-end** against a real SQL Server (local
  container): the #62 migration applied from scratch, creating `Party`, `Guest`,
  `AuditEntry`, `Settings`. `ensure-db-user.mjs` syntax + input-guard checked.
- **Only provable at first staging apply:** the AAD/managed-identity grant
  (`CREATE USER ... FROM EXTERNAL PROVIDER` + `DefaultAzureCredential`) — it can't
  run against a local SQL-auth container. Called out, not claimed as proven.
- No live `apply` from this PR — `infra.yml` applies on merge (shared/production gated).

## Code review

**Fixed** (`/code-review high --fix`):
- The migrate step guard always read false because the deploy job never checked
  out the repo — migrations would have silently never run. Added
  `actions/checkout`. (Guard sentinel later changed to `ensure-db-user.mjs` during
  the #62 rebase — see above.)

**Left open (your call):**
- When `ENABLE_DB_MIGRATIONS=true`, a manual image-rollback (`workflow_dispatch`)
  still applies forward migrations against the older image — a schema/code-skew
  hazard. Prisma migrations are forward-only; mitigate with expand-contract
  migrations, or temporarily unset the flag when rolling back.
- The migrate runner-IP lookup uses `api.ipify.org` under `set -e`, coupling a
  migrating deploy to that third-party service.

## Cost note (deliberately exceeds the issue's "~$5/mo" acceptance)

Staging auto-pauses (~$5/mo storage floor). **Production runs warm** (auto-pause
disabled, min 0.5 vCore, ~$15–30/mo) to avoid a first-query resume delay —
consistent with production's warm `min_replicas = 1` policy. Flagged per your
brainstorm choice.

## Prerequisites before merge (Owner-run, not CI)

1. **Before the first `infra` apply:** the `czw-sql-admins` Entra group +
   `SQL_AAD_ADMIN_GROUP_OBJECT_ID` / `SQL_AAD_ADMIN_GROUP_NAME` repo variables
   must exist, or the plan fails on an unset var. `bootstrap-azure.sh` creates
   them (needs an Entra directory role — subscription Ownership alone isn't
   enough). Bootstrap also grants the deploy identity `SQL Server Contributor` on
   the app RGs and adds it to `czw-sql-admins`.
2. **To turn migrations on** (after the first `staging` apply creates the server):
   `gh variable set ENABLE_DB_MIGRATIONS --body true`. Off by default, so nothing
   runs until you opt in.

See the RSVP database section in `docs/deployment/README.md`.

## Known risks (documented in the plan)

- `azuread_authentication_only` with an omitted admin login is only provable at
  the first real `apply` (validate can't check runtime API requirements).
- `sql-czw-<env>` must be globally unique; add a random suffix if a name clashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
