### PR TITLE
ship-it: token/time efficiency + subagent delegation + self-improvement loop

### DIFF
--- a/.claude/skills/ship-it/LEARNINGS.md
+++ b/.claude/skills/ship-it/LEARNINGS.md
@@ -13,9 +13,8 @@ Pending (not yet folded into `SKILL.md`):
   lost several turns discovering Podman (`/opt/podman/bin`), a port-1433 conflict
   with a pre-existing container, and a SQL Server 2025 AVX crash under Rosetta.
   Check the container runtime + DB port availability up front, not at verify time.
-- **Research bloated main context.** Version/API grounding (Prisma 7 via web +
-  context7) dumped raw docs inline and never left context. Delegate grounding to
-  a subagent that returns a short decision memo.
 
-Promoted into `SKILL.md` (gate mirrors CI, `docker build` runs once, output is
-trimmed — Phase 6/7): stale-gate, repeated-heavy-checks, untrimmed-output.
+Promoted into `SKILL.md`:
+- gate mirrors CI, `docker build` runs once, output trimmed (Phase 6/7).
+- research grounding delegated to a subagent memo (Phase 4); per-task work and
+  heavy verify delegated to cheaper-model subagents (Phase 5/6, Notes).

--- a/.claude/skills/ship-it/LEARNINGS.md
+++ b/.claude/skills/ship-it/LEARNINGS.md
@@ -7,17 +7,15 @@ tweak — and prune what's been folded in. This file is how the skill improves.
 
 ## 2026-07-18 — issue #62 (RSVP data layer)
 
-- **Gate is stale.** `SKILL.md` says "there is no test suite," but the repo now
-  has a vitest suite (`npm test`) and CI runs both `npm test` and `docker build`.
-  Verify should mirror CI: `lint → check:images → test → build → docker build`.
+Pending (not yet folded into `SKILL.md`):
+
 - **No environment precheck.** The `docker` CLI was a dangling symlink; the run
   lost several turns discovering Podman (`/opt/podman/bin`), a port-1433 conflict
   with a pre-existing container, and a SQL Server 2025 AVX crash under Rosetta.
   Check the container runtime + DB port availability up front, not at verify time.
-- **Heavy checks re-ran.** `docker build` ran three times (after impl, after
-  review, after a fix). Run CI-parity / heavy checks **once**, at the end.
 - **Research bloated main context.** Version/API grounding (Prisma 7 via web +
   context7) dumped raw docs inline and never left context. Delegate grounding to
   a subagent that returns a short decision memo.
-- **Verify output not trimmed.** Full gate and `docker build` output entered
-  context verbatim. Pipe to `tail`/`grep`; keep pass/fail + failing lines only.
+
+Promoted into `SKILL.md` (gate mirrors CI, `docker build` runs once, output is
+trimmed — Phase 6/7): stale-gate, repeated-heavy-checks, untrimmed-output.

--- a/.claude/skills/ship-it/LEARNINGS.md
+++ b/.claude/skills/ship-it/LEARNINGS.md
@@ -5,16 +5,25 @@ a dated bullet whenever a run hits friction the skill didn't anticipate (Phase 9
 Periodically **promote** recurring entries into `SKILL.md` — a gotcha, a phase
 tweak — and prune what's been folded in. This file is how the skill improves.
 
-## 2026-07-18 — issue #62 (RSVP data layer)
+## Machine quirks (consult during Phase 0)
 
-Pending (not yet folded into `SKILL.md`):
+Persistent facts about the current dev machine — not todos; Phase 0 reads these.
 
-- **No environment precheck.** The `docker` CLI was a dangling symlink; the run
-  lost several turns discovering Podman (`/opt/podman/bin`), a port-1433 conflict
-  with a pre-existing container, and a SQL Server 2025 AVX crash under Rosetta.
-  Check the container runtime + DB port availability up front, not at verify time.
+- **Container runtime:** the `docker` CLI is a dangling symlink (Docker Desktop
+  uninstalled). Use Podman — `export PATH="/opt/podman/bin:$PATH"`; the
+  `podman-machine-default` (applehv, Rosetta) is normally already running.
+- **DB port:** host `1433` is taken by another local SQL Server container. The
+  wedding DB uses host `14330` (`docker-compose.dev.yml`); don't disturb the other.
+- **SQL Server image:** 2025 crashes under Podman/Rosetta with an AVX assertion —
+  use `2022-latest`. Deeper context: personal memory `rsvp-data-layer-stack`.
 
-Promoted into `SKILL.md`:
-- gate mirrors CI, `docker build` runs once, output trimmed (Phase 6/7).
-- research grounding delegated to a subagent memo (Phase 4); per-task work and
-  heavy verify delegated to cheaper-model subagents (Phase 5/6, Notes).
+## Run log
+
+Append a dated bullet when a run hits friction the skill didn't anticipate. Once a
+lesson is folded into `SKILL.md` (or captured as a machine quirk above), prune it.
+
+### 2026-07-18 — issue #62 (RSVP data layer)
+
+All findings folded into `SKILL.md` (Phase 0 precheck, Phase 4 research memos,
+Phase 5 subagent-driven impl, Phase 6/7 CI-mirrored gate + one-time docker + output
+trimming) or captured as machine quirks above. No pending items.

--- a/.claude/skills/ship-it/LEARNINGS.md
+++ b/.claude/skills/ship-it/LEARNINGS.md
@@ -1,0 +1,23 @@
+# ship-it — Learnings
+
+A running log of what the skill under-specified, or what surprised a run. Append
+a dated bullet whenever a run hits friction the skill didn't anticipate (Phase 9).
+Periodically **promote** recurring entries into `SKILL.md` — a gotcha, a phase
+tweak — and prune what's been folded in. This file is how the skill improves.
+
+## 2026-07-18 — issue #62 (RSVP data layer)
+
+- **Gate is stale.** `SKILL.md` says "there is no test suite," but the repo now
+  has a vitest suite (`npm test`) and CI runs both `npm test` and `docker build`.
+  Verify should mirror CI: `lint → check:images → test → build → docker build`.
+- **No environment precheck.** The `docker` CLI was a dangling symlink; the run
+  lost several turns discovering Podman (`/opt/podman/bin`), a port-1433 conflict
+  with a pre-existing container, and a SQL Server 2025 AVX crash under Rosetta.
+  Check the container runtime + DB port availability up front, not at verify time.
+- **Heavy checks re-ran.** `docker build` ran three times (after impl, after
+  review, after a fix). Run CI-parity / heavy checks **once**, at the end.
+- **Research bloated main context.** Version/API grounding (Prisma 7 via web +
+  context7) dumped raw docs inline and never left context. Delegate grounding to
+  a subagent that returns a short decision memo.
+- **Verify output not trimmed.** Full gate and `docker build` output entered
+  context verbatim. Pipe to `tail`/`grep`; keep pass/fail + failing lines only.

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -84,15 +84,35 @@ Classify the issue to right-size planning:
   `docs/superpowers/specs/YYYY-MM-DD-<topic>-design.md`. Present the plan and
   wait for approval.
 
+**Grounding (either size):** when the plan hinges on an external fact — a library
+version, an API shape, a platform limit — do **not** pull raw docs (web search,
+context7, MCP) into this context. Dispatch a research subagent (a cheaper model is
+fine) with the specific question; have it return a short **decision memo** (the
+answer + the source URL) and discard the raw pages. Un-delegated research is a
+large, silent context cost.
+
 **Do not proceed to implementation until the user approves the plan.**
 
 ## Phase 5 — Implement (autonomous)
 
-Build the change in the worktree per the approved plan. Follow `AGENTS.md`
+Build the change in the worktree per the approved plan, following `AGENTS.md`
 conventions (Tailwind-only, `@/` alias, data in `src/constants/*`, client/server
-boundary rules). Where a test surface exists, use
-`superpowers:test-driven-development`; this repo is largely test-free, so most
-work is direct implementation validated by the gate below.
+boundary rules).
+
+**Delegate by size — the main lever for token spend and speed:**
+
+- **Small** → implement **inline**. A single-file mechanical change is not worth a
+  subagent's cold start (a fresh subagent re-derives context you already hold).
+- **Large** → run the approved plan via `superpowers:subagent-driven-development`:
+  one subagent per plan task on a cheaper model (e.g. Sonnet), review the returned
+  diff between tasks, and keep only **task summaries + diffs** in this context — not
+  the whole working set. The plan's per-task `Consumes`/`Produces` interface blocks
+  exist precisely so a cold subagent can execute one task in isolation. The
+  orchestrator stays on the stronger model and only reviews.
+
+Where a test surface exists, have the implementing agent use
+`superpowers:test-driven-development`. One task in flight at a time; a task is done
+only when its slice of the gate is green.
 
 ## Phase 6 — Verify (autonomous)
 
@@ -114,7 +134,8 @@ rendered behavior.
 The heavy **CI-parity check** — `docker build` (or `podman build`; see
 `LEARNINGS.md`) — is slow (image pull + `npm ci` + build) and its output is large.
 Run it **once**, at the end (Phase 7, after review, before pushing) — never after
-every change.
+every change. Delegating it to a verify subagent that returns only pass/fail plus
+any failing lines keeps its large output out of the orchestrator.
 
 ## Phase 7 — Code review (autonomous)
 
@@ -181,6 +202,10 @@ When the verify gate (Phase 6/7) or code review fails:
 
 ## Notes
 
+- The orchestrator runs on the stronger model and mostly **reviews**; push the
+  grunt work — research grounding, per-task implementation, heavy verification — to
+  cheaper-model subagents, and keep only their memos, diffs, and pass/fail in this
+  context. Delegation earns its cold-start cost on **Large** issues, not Small ones.
 - One issue in flight at a time; finish and verify before starting another.
 - Never skip the plan-approval or PR checkpoints, even for trivial issues.
 - Keep the branch/worktree/PR naming consistent: `issue-<n>-<slug>` throughout.

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -11,9 +11,10 @@ checkpoints — **plan approval** and **final PR review** — and running the mi
 autonomously.
 
 You are working on the **wedding-website** repo. `gh` is authenticated. All paths
-are relative to the repo root. The verification gate is
-`npm run lint && npm run build && npm run check:images` (there is no test suite —
-see `AGENTS.md`).
+are relative to the repo root. The verification gate **mirrors CI**
+(`.github/workflows/ci.yml`): `npm run lint && npm run check:images && npm test &&
+npm run build`, plus a one-time `docker build` for CI parity. Run the fast gate as
+often as needed; run `docker build` once, at the end.
 
 ## Checkpoint model
 
@@ -95,16 +96,25 @@ work is direct implementation validated by the gate below.
 
 ## Phase 6 — Verify (autonomous)
 
-Run the full gate **in the worktree**:
+Run the fast gate **in the worktree**, in CI order:
 
 ```bash
-npm run lint && npm run build && npm run check:images
+npm run lint && npm run check:images && npm test && npm run build
 ```
 
-Show the actual output. On failure, apply the [Failure handling](#failure-handling)
-rule. For UI/runtime-visible changes, additionally drive the app per the
+**Trim output** — pipe long commands to `tail`/`grep` and keep pass/fail plus any
+failing lines. "Show the actual output" means the evidence, not the whole dump;
+verbatim gate and build logs are the biggest avoidable context cost.
+
+On failure, apply the [Failure handling](#failure-handling) rule. For
+UI/runtime-visible changes, additionally drive the app per the
 `run-wedding-website` skill and view the result — a green gate does not prove
 rendered behavior.
+
+The heavy **CI-parity check** — `docker build` (or `podman build`; see
+`LEARNINGS.md`) — is slow (image pull + `npm ci` + build) and its output is large.
+Run it **once**, at the end (Phase 7, after review, before pushing) — never after
+every change.
 
 ## Phase 7 — Code review (autonomous)
 
@@ -115,8 +125,14 @@ Run a code review over the diff and auto-apply its fixes:
 ```
 
 Capture each finding's outcome (`fixed` / `skipped`) — these feed the PR body.
-Because fixes can break the build, **re-run the Phase 6 gate** after review and
-apply the same failure rule.
+Because fixes can break the build, **re-run the Phase 6 fast gate** after review.
+Then run the one-time CI-parity check before shipping:
+
+```bash
+docker build -t czw:ci .   # or: podman build -t czw:ci .
+```
+
+Apply the [Failure handling](#failure-handling) rule to both.
 
 ## Phase 8 — Ship ⏸
 

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -27,6 +27,22 @@ often as needed; run `docker build` once, at the end.
 
 Announce the current phase as you enter it so the run is legible.
 
+## Phase 0 — Environment precheck
+
+Before touching the issue, confirm the tools the run will need so substitutions
+surface now, not at the verify gate. Read `LEARNINGS.md` first for this machine's
+known quirks, then check only what the issue will actually use:
+
+- **Container runtime** (only if the change may touch the DB or Docker): is a
+  runtime on PATH? `docker` may be a dangling symlink here — fall back to `podman`
+  and confirm its machine is running. Note which command the rest of the run uses.
+- **DB port** (only if the work needs a local database): confirm the target host
+  port is free before `db:up` — a pre-existing container may hold the default.
+- **Gate tools**: `node`/`npm` satisfy `engines`; `gh` is authenticated.
+
+Keep this to a few quick commands. Don't block a docs- or content-only issue on
+container checks it will never use.
+
 ## Phase 1 — Resolve the issue
 
 If an issue number was given, fetch it:

--- a/.claude/skills/ship-it/SKILL.md
+++ b/.claude/skills/ship-it/SKILL.md
@@ -143,6 +143,17 @@ Left open (your call): <finding that review skipped> …
 Report the PR URL. The run ends here — the user reviews the PR. Leave the
 worktree in place (this repo keeps them; do not auto-remove).
 
+## Phase 9 — Retro (autonomous)
+
+Close the improvement loop. If anything surprised you or the skill
+under-specified a step — a stale command, a missing env check, a wrong
+assumption, a gotcha that cost turns — append one dated bullet per learning to
+`.claude/skills/ship-it/LEARNINGS.md`. Skip silently on a frictionless run.
+
+When a learning **recurs** across runs, promote it into this `SKILL.md` (a gotcha
+or a phase tweak) and prune the folded entry from `LEARNINGS.md`. That promotion
+is what makes the skill improve over time rather than relearning the same lesson.
+
 ## Failure handling
 
 When the verify gate (Phase 6/7) or code review fails:
@@ -157,3 +168,5 @@ When the verify gate (Phase 6/7) or code review fails:
 - One issue in flight at a time; finish and verify before starting another.
 - Never skip the plan-approval or PR checkpoints, even for trivial issues.
 - Keep the branch/worktree/PR naming consistent: `issue-<n>-<slug>` throughout.
+- Read `LEARNINGS.md` at the start of a run for known gotchas; log new ones there
+  at the end (Phase 9). The skill is meant to get sharper each run.


### PR DESCRIPTION
Improves the `ship-it` skill for token spend, wall-clock time, and continual self-improvement — grounded in friction observed running it on issue #62 (PR #75). Four atomic commits, docs-only (no runtime code).

## Changes

- **Feedback loop** (`c9e249f`) — new **Phase 9 Retro** + seeded `LEARNINGS.md`. Each run logs surprises; recurring ones get promoted into `SKILL.md`. This is the engine that makes the skill sharpen over time instead of relearning.
- **Verify efficiency** (`5a76cd0`) — Phase 6 gate now mirrors CI (`lint → check:images → test → build`), fixing the stale "there is no test suite" claim. `docker build` becomes a **one-time** CI-parity check at the end of Phase 7 (it ran 3× in #62). Output-trimming is mandated — verbatim gate/build logs were the biggest avoidable context cost.
- **Subagent delegation** (`2c6179c`) — the main token lever. Phase 4 grounds external facts via a research subagent that returns a **memo** (not raw web/context7 dumps); Phase 5 runs **Large** issues through `subagent-driven-development` (one cheaper-model subagent per plan task, orchestrator reviews diffs); heavy verify is delegable. **Small** issues stay inline so cold-start cost is never paid where it doesn't earn out.
- **Environment precheck** (`e3f97a1`) — new **Phase 0** front-loads container-runtime / DB-port / tooling checks that cost turns mid-run in #62 (dangling `docker` CLI → podman, port-1433 conflict, SQL Server 2025 AVX crash under Rosetta).

## The loop already paid off

`LEARNINGS.md` was seeded with five findings from the #62 run. Commits #2–#4 folded each into `SKILL.md` and pruned it — the pending list is now empty, with durable machine facts (podman, host port 14330, SQL 2025 AVX) kept as a "Machine quirks" reference that Phase 0 reads. End-to-end demonstration of the mechanism.

## Note

Delegation is deliberately gated to **Large** issues (where the plan's per-task `Consumes`/`Produces` interface blocks make a cold subagent cheap); Small stays inline, so the skill won't over-spawn on trivial work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
