### PR TITLE
fix(bootstrap): register Microsoft.Sql provider namespace (#61)

### DIFF
--- a/scripts/bootstrap-azure.sh
+++ b/scripts/bootstrap-azure.sh
@@ -64,7 +64,7 @@ echo "==> Register resource providers (async; finishes in the background before 
 # = "none"), so every namespace it touches must be registered here.
 for ns in Microsoft.App Microsoft.OperationalInsights Microsoft.ContainerRegistry \
           Microsoft.Insights Microsoft.ManagedIdentity Microsoft.Storage \
-          Microsoft.Consumption Microsoft.Authorization; do
+          Microsoft.Sql Microsoft.Consumption Microsoft.Authorization; do
   az provider register --namespace "$ns" --only-show-errors -o none
 done
 


### PR DESCRIPTION
Follow-up to #74. The first Infra apply after merging the RSVP database 409'd:

```
MissingSubscriptionRegistration: The subscription is not registered to use namespace 'Microsoft.Sql'
```

## Root cause
The azurerm provider runs with `resource_provider_registrations = "none"` — the RG-Contributor CI identity can't register providers at subscription scope, so `bootstrap-azure.sh` registers every namespace the stack uses. The Azure SQL work in #74 added a new resource type but didn't add `Microsoft.Sql` to that list.

## Fix
Add `Microsoft.Sql` to the bootstrap provider-registration loop (one line).

## To recover
Re-run `bootstrap-azure.sh` (registers `Microsoft.Sql`, async ~1–2 min to reach `Registered`), then re-run the Infra workflow. No Terraform or live-resource changes here — registration is a subscription-level enablement bootstrap already owns.

Note: the companion gap (the `SQL_AAD_ADMIN_GROUP_OBJECT_ID` / `_NAME` repo variables) was already set by #74's bootstrap changes; re-running bootstrap confirms them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)